### PR TITLE
Turning the allocator into an overt exercise in data structure composition, part 1

### DIFF
--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -1101,53 +1101,6 @@ class MState
 			}
 		}
 	}
-	// Can this chunk can be found in a bin?
-	bool bin_find(MChunk *x)
-	{
-		size_t size = x->size_get();
-		if (is_small(size))
-		{
-			BIndex  sidx = small_index(size);
-			MChunk *b    = smallbin_at(sidx);
-			if (is_smallmap_marked(sidx))
-			{
-				MChunk *p = b;
-				do
-				{
-					if (p == x)
-					{
-						return true;
-					}
-				} while ((p = ptr2chunk(p->fd)) != b);
-			}
-		}
-		else
-		{
-			BIndex tidx = compute_tree_index(size);
-			if (is_treemap_marked(tidx))
-			{
-				TChunk *t        = *treebin_at(tidx);
-				size_t  sizebits = size << leftshift_for_tree_index(tidx);
-				while (t != nullptr && t->size_get() != size)
-				{
-					t = t->child[leftshifted_val_msb(sizebits)];
-					sizebits <<= 1;
-				}
-				if (t != nullptr)
-				{
-					TChunk *u = t;
-					do
-					{
-						if (u == static_cast<TChunk *>(x))
-						{
-							return true;
-						}
-					} while ((u = ptr2tchunk(u->fd)) != t);
-				}
-			}
-		}
-		return false;
-	}
 	// Sanity check the entire malloc state in this MState.
 	void ok_malloc_state()
 	{

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -515,9 +515,7 @@ static_assert(ds::linked_list::cell::HasCellOperations<MChunkHeader>);
  * is of course much better.
  */
 
-static constexpr ptrdiff_t MChunkFreeRingOffset = 8;
-using ChunkFreeLink =
-  ds::linked_list::cell::OffsetPtrAddr<MChunkFreeRingOffset>;
+using ChunkFreeLink = ds::linked_list::cell::PtrAddr;
 
 /**
  * Class of a free allocator chunk's metadata.

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -559,55 +559,6 @@ MChunk
 	friend class MState;
 
 	public:
-	bool is_in_use()
-	{
-		return header.is_in_use();
-	}
-	bool is_prev_in_use()
-	{
-		return header.is_prev_in_use();
-	}
-
-	// Returns the next adjacent chunk.
-	MChunk *chunk_next()
-	{
-		return MChunk::from_header(header.cell_next());
-	}
-	// Returns the previous adjacent chunk.
-	MChunk *chunk_prev()
-	{
-		return MChunk::from_header(header.cell_prev());
-	}
-
-	// size of the previous chunk
-	size_t prevsize_get()
-	{
-		return header.prevsize_get();
-	}
-	// size of this chunk
-	size_t size_get()
-	{
-		return header.size_get();
-	}
-
-	/**
-	 * Set the in-use bit of this chunk, which takes care of setting the
-	 * previous-in-use bit in the next chunk as well. Should only be called when
-	 * size has been populated, otherwise it will not find the next chunk.
-	 */
-	void in_use_set()
-	{
-		header.mark_in_use();
-	}
-	/**
-	 * Clear the in-use bit of this chunk and the previous-in-use bit of the
-	 * next chunk.  Size of this chunk must have been set.
-	 */
-	void in_use_clear()
-	{
-		header.mark_free();
-	}
-
 	// Is the bk field pointing to p?
 	bool bk_equals(MChunk * p)
 	{

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -651,35 +651,6 @@ MChunk
 		return MChunk::from_header(header.split(offset));
 	}
 
-#ifdef NDEBUG
-	bool ok_in_use()
-	{
-		return true;
-	}
-	bool ok_prev_in_use()
-	{
-		return true;
-	}
-	bool ok_next(MChunk * n)
-	{
-		return true;
-	}
-#else
-	bool ok_in_use()
-	{
-		return is_in_use();
-	}
-	bool ok_prev_in_use()
-	{
-		return is_prev_in_use();
-	}
-	// Sanity check that the next chunk is indeed higher than this one.
-	bool ok_next(MChunk * n)
-	{
-		return ptr() < n->ptr();
-	}
-#endif
-
 	// Write the revocation epoch into the header.
 	void epoch_write()
 	{

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -744,11 +744,19 @@ TChunk
 		t->mark_tree_ring();
 	}
 
+	/**
+	 * Wipe the TChunk metadata.
+	 */
 	__always_inline void metadata_clear()
 	{
-		mchunk.metadata_clear();
-		child[0] = child[1] = parent = nullptr;
-		index                        = 0;
+		/*
+		 * This is spelled slightly oddly as using memset results in a call
+		 * rather than a few store instructions.  Even a loop with constant
+		 * limits lowers to an actual loop.
+		 */
+		static_assert(sizeof(*this) == 5 * sizeof(uintptr_t));
+		uintptr_t *body = reinterpret_cast<uintptr_t *>(this);
+		body[0] = body[1] = body[2] = body[3] = body[4] = 0;
 	}
 };
 

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -2054,6 +2054,9 @@ class MState
 		void  *mem;
 		size_t nb;
 
+		/* Move O(1) nodes from quarantine, if any are available */
+		quarantine_dequeue();
+
 		if (bytes <= MaxSmallRequest)
 		{
 			BIndex idx;
@@ -2109,16 +2112,9 @@ class MState
 
 		/*
 		 * Exhausted all allocation options. Force start a revocation or
-		 * continue with synchronous revocation. If kick returns 0, then there's
-		 * nothing in the quarantine and we run out of memory for real.
-		 *
-		 * If we do have leftovers in the quarantine, dequeue the entire
-		 * quarantine and punt to the caller to retry.
+		 * continue with synchronous revocation.
 		 */
-		if (mspace_bg_revoker_kick<true>())
-		{
-			mspace_qtbin_deqn(UINT32_MAX);
-		}
+		mspace_bg_revoker_kick<true>();
 		return nullptr;
 	}
 

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -617,13 +617,6 @@ constexpr size_t MinChunkSize =
 // the minimum size of a chunk (excluding the header)
 constexpr size_t MinRequest = MinChunkSize - sizeof(MChunkHeader);
 
-// Convert a user pointer back to the chunk.
-static inline MChunkHeader *mem2chunk(CHERI::Capability<void> p)
-{
-	p.address() -= MallocAlignment;
-	return p.cast<MChunkHeader>();
-}
-
 // true if cap address a has acceptable alignment
 static inline bool is_aligned(CHERI::Capability<void> a)
 {
@@ -997,7 +990,7 @@ class MState
 		 * Rederived into allocator capability. From now on faults on this
 		 * pointer are internal.
 		 */
-		MChunkHeader *p = mem2chunk(mem);
+		auto p = MChunkHeader::from_body(mem);
 		// At this point, we know mem is capability aligned.
 		capaligned_zero(mem, p->size_get() - sizeof(MChunkHeader));
 		revoker.shadow_paint_range(mem.address(), p->cell_next(), true);

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -348,6 +348,23 @@ MChunkHeader
 	}
 
 	/**
+	 * Obtain a pointer to the body of this chunk.
+	 *
+	 * This relies on the CHERI bounds of `this` being (at least) to the
+	 * entire object.  In practice, they will be to the entire heap.
+	 */
+	template<typename T = void>
+	__always_inline CHERI::Capability<T> body()
+	{
+		return ds::pointer::offset<T>(this, sizeof(MChunkHeader));
+	}
+
+	static MChunkHeader *from_body(void *body)
+	{
+		return ds::pointer::offset<MChunkHeader>(body, -sizeof(MChunkHeader));
+	}
+
+	/**
 	 * Land a new header somewhere within an existing chunk.
 	 *
 	 * The resulting header inherits its in-use status from this one, which

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -793,7 +793,7 @@ class MState
 	 *
 	 * Returns true if any objects were dequeued, false otherwise.
 	 */
-	bool quarantine_dequeue()
+	__always_inline bool quarantine_dequeue()
 	{
 		// 4 chosen by fair die roll.
 		return mspace_qtbin_deqn(4) > 0;

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -1503,6 +1503,13 @@ class MState
 			}
 		}
 
+		/*
+		 * Prefer to unlink a ring node rather than a tree node, as this
+		 * simplifies the work in unlink_large_chunk() below, leaving the
+		 * tree structure unmodified.
+		 */
+		v = TChunk::from_ring(v->ring.cell_next());
+
 		if (RTCHECK(ok_address(v->ptr())))
 		{
 			MChunk *r = v->chunk_plus_offset(nb);

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -55,12 +55,12 @@ static_assert(NSmallBins < utils::bytes2bits(sizeof(Binmap)));
 static_assert(NTreeBins < utils::bytes2bits(sizeof(Binmap)));
 
 // Convert small size header into the actual size in bytes.
-static inline size_t head2size(SmallSize h)
+static inline constexpr size_t head2size(SmallSize h)
 {
 	return static_cast<size_t>(h) << MallocAlignShift;
 }
 // Convert byte size into small size header.
-static inline SmallSize size2head(size_t s)
+static inline constexpr SmallSize size2head(size_t s)
 {
 	return s >> MallocAlignShift;
 }

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -432,6 +432,13 @@ MChunkHeader
 
 		return first;
 	}
+
+	private:
+	/*
+	 * Hide a no-op constructor; the only calls should be make() and split()
+	 * above, which carry out initialization.
+	 */
+	MChunkHeader() = default;
 };
 static_assert(sizeof(MChunkHeader) == 8);
 static_assert(std::is_standard_layout_v<MChunkHeader>);

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -928,13 +928,15 @@ class MState
 			Debug::Assert(
 			  next->prevsize_get() == sz,
 			  "Chunk {} has size {}, next node expects its size to be {}",
+			  next,
 			  sz,
 			  next->prevsize_get());
 			Debug::Assert(p->is_prev_in_use(),
-			              "Free chunk {} should follow an in-use chunk");
-			Debug::Assert(
-			  next->is_in_use(),
-			  "Free chunk {} should be followed by an in-use chunk");
+			              "Free chunk {} should follow an in-use chunk",
+			              p);
+			Debug::Assert(next->is_in_use(),
+			              "Free chunk {} should be followed by an in-use chunk",
+			              next);
 			Debug::Assert(
 			  ptr2chunk(p->fd)->bk_equals(p),
 			  "Forward and backwards chunk pointers are inconsistent for {}",
@@ -1056,7 +1058,8 @@ class MState
 		Debug::Assert(t->parent != t, "Chunk {} is its own parent", t);
 		Debug::Assert(t->is_root() || t->parent->child[0] == t ||
 		                t->parent->child[1] == t,
-		              "Chunk {} is neither root nor a child of its parent");
+		              "Chunk {} is neither root nor a child of its parent",
+		              t);
 
 		/* Equal-sized chunks */
 		TChunk *u = ptr2tchunk(t->fd);
@@ -1516,7 +1519,8 @@ class MState
 			              v->size_get(),
 			              rsize + nb);
 			Debug::Assert(v->is_prev_in_use(),
-			              "Free chunk {} follows another free chunk");
+			              "Free chunk {} follows another free chunk",
+			              v);
 			if (RTCHECK(v->ok_next(r)))
 			{
 				unlink_large_chunk(v);

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -695,22 +695,37 @@ TChunk
 		return child[1];
 	}
 
+	/**
+	 * Fictitious root for ring-linked nodes
+	 */
 	static constexpr uintptr_t RingParent = 0;
+
+	/**
+	 * Fictitious root for roots of tree bins.
+	 */
 	static constexpr uintptr_t RootParent = 1;
 
+	/**
+	 * Is this the root of a tree bin?
+	 */
 	bool is_root()
 	{
 		return reinterpret_cast<uintptr_t>(parent) == RootParent;
 	}
 
+	/**
+	 * Is this TChunk linked by its mchunk.ring to the tree, rather than its
+	 * parent/child nodes?  That is, is there an equal-size node already in
+	 * the tree?
+	 */
 	bool is_tree_ring()
 	{
 		return parent == reinterpret_cast<TChunk *>(RingParent);
 	}
 
 	/**
-	 * TChunk's `ring` fields are sentinels for their rings of equal-sized
-	 * nodes.
+	 * TChunk's `mchunk.ring` fields are sentinels for their rings of
+	 * equal-sized nodes.
 	 */
 	template<typename F>
 	bool ring_search(F f)
@@ -720,13 +735,18 @@ TChunk
 		});
 	}
 
+	/**
+	 * Convenience composition of two container-of operations to get us from
+	 * a TChunk's ring node back to the TChunk.
+	 */
 	__always_inline static TChunk *from_ring(ChunkFreeLink * c)
 	{
 		return TChunk::from_mchunk(MChunk::from_ring(c));
 	}
 
 	/**
-	 * Insert t on the same free ring as this and initialize its linkages.
+	 * Construct a TChunk in `tHeader`, place it on the same free ring as
+	 * `this`, and initialize its linkages.
 	 */
 	__always_inline void ring_emplace(BIndex ix, MChunkHeader * tHeader)
 	{
@@ -752,14 +772,24 @@ TChunk
 		body[0] = body[1] = body[2] = body[3] = body[4] = 0;
 	}
 
+	/**
+	 * Construct a root leaf node for the given trie index.
+	 */
 	TChunk(BIndex ix)
 	  : index(ix), parent(reinterpret_cast<TChunk *>(RootParent))
 	{
 	}
 
+	/**
+	 * Construct a non-root leaf node for the given trie index with indicated
+	 * parent.
+	 */
 	TChunk(BIndex ix, TChunk * p) : index(ix), parent(p) {}
 
 	public:
+	/**
+	 * Remove default constructor
+	 */
 	TChunk() = delete;
 };
 

--- a/sdk/core/allocator/alloc_config.h
+++ b/sdk/core/allocator/alloc_config.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
+#include <compartment.h>
 #include <debug.hh>
 #include <stdlib.h>
-#include <compartment.h>
 
 using Debug = ConditionalDebug<DEBUG_ALLOCATOR, "Allocator">;
 
@@ -16,9 +16,10 @@ using Debug = ConditionalDebug<DEBUG_ALLOCATOR, "Allocator">;
 #	define RTCHECK(e) (1)
 #else
 #	define RTCHECK(e) (e)
-constexpr size_t MSTATE_SANITY_INTERVAL = 128;
+constexpr size_t MStateSanityInterval = 128;
 #endif
 
-constexpr size_t MALLOC_ALIGNSHIFT = 3;
-constexpr size_t MALLOC_ALIGNMENT  = 1U << MALLOC_ALIGNSHIFT;
-constexpr size_t MALLOC_ALIGNMASK  = MALLOC_ALIGNMENT - 1;
+constexpr size_t MallocAlignShift = 3;
+
+constexpr size_t MallocAlignment = 1U << MallocAlignShift;
+constexpr size_t MallocAlignMask = MallocAlignment - 1;

--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -57,7 +57,7 @@ namespace
 		 * but not too big that overflows what the compressed header can
 		 * support.
 		 */
-		if (tsize < msize + MinChunkSize + ChunkOverhead ||
+		if (tsize < msize + MinChunkSize + sizeof(MChunkHeader) ||
 		    tsize > MaxChunkSize)
 		{
 			return nullptr;

--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -57,14 +57,14 @@ namespace
 		 * but not too big that overflows what the compressed header can
 		 * support.
 		 */
-		if (tsize < msize + MIN_CHUNK_SIZE + CHUNK_OVERHEAD ||
-		    tsize > MAX_CHUNK_SIZE)
+		if (tsize < msize + MinChunkSize + ChunkOverhead ||
+		    tsize > MaxChunkSize)
 		{
 			return nullptr;
 		}
 
 		// At this point, the entire heap should be zeroed.
-		size_t firstchunksize = tsize - msize - CHUNK_OVERHEAD;
+		size_t firstchunksize = tsize - msize - ChunkOverhead;
 
 		MChunk    *msp = tbase.cast<MChunk>();
 		Capability m{chunk2mem(msp).cast<MState>()};
@@ -80,7 +80,7 @@ namespace
 
 		MChunk *footer = mn->chunk_next();
 		// The footer is a fake chunk with only the header.
-		footer->footchunk_set(CHUNK_OVERHEAD);
+		footer->footchunk_set(ChunkOverhead);
 		// The footer should be at the very end of this region.
 		Debug::Assert(chunk2mem(footer).address() == (tbase.address() + tsize),
 		              "Footer ({}) is not at the end of the region {} + {}",
@@ -238,7 +238,7 @@ namespace
 	 * free(). Now the bit has served its purpose, clear it. This is also to
 	 * detect double free.
 	 */
-	revoker.shadow_paint_single(mem.address() - MALLOC_ALIGNMENT, false);
+	revoker.shadow_paint_single(mem.address() - MallocAlignment, false);
 	gm->mspace_free(mem);
 
 	// If there are any threads blocked allocating memory, wake them up.

--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -69,10 +69,10 @@ namespace
 		MChunk    *msp = tbase.cast<MChunk>();
 		Capability m{chunk2mem(msp).cast<MState>()};
 
-		m.bounds() = sizeof(*m);
-		m->init_bins();
+		m.bounds()            = sizeof(*m);
 		m->heapStart          = tbase;
 		m->heapStart.bounds() = tsize;
+		m->init_bins();
 		msp->in_use_chunk_set(msize);
 
 		MChunk *mn = msp->chunk_next();

--- a/sdk/core/allocator/revoker.h
+++ b/sdk/core/allocator/revoker.h
@@ -58,7 +58,7 @@ namespace Revocation
 		 *
 		 * @param fill true to set, false to clear the bit
 		 */
-		void shadow_paint_single(size_t addr, bool fill)
+		void shadow_paint_single(ptraddr_t addr, bool fill)
 		{
 			Debug::Assert(addr > TCMBaseAddr,
 			              "Address {} is below the TCM base {}",
@@ -85,18 +85,19 @@ namespace Revocation
 		 *
 		 * @param fill true to set, false to clear the bits
 		 */
-		void shadow_paint_range(size_t base, size_t top, bool fill)
+		void shadow_paint_range(ptraddr_t base, ptraddr_t top, bool fill)
 		{
 			constexpr size_t ShadowWordAddrMask =
 			  (1U << (ShadowWordShift + MallocAlignShift)) - 1;
-			size_t baseUp  = (base + ShadowWordAddrMask) & ~ShadowWordAddrMask;
-			size_t topDown = top & ~ShadowWordAddrMask;
+			ptraddr_t baseUp =
+			  (base + ShadowWordAddrMask) & ~ShadowWordAddrMask;
+			ptraddr_t topDown = top & ~ShadowWordAddrMask;
 
 			// There isn't a single aligned shadow word for this range, so paint
 			// one bit at a time.
 			if (baseUp >= topDown)
 			{
-				for (size_t ptr = base; ptr < top; ptr += MallocAlignment)
+				for (ptraddr_t ptr = base; ptr < top; ptr += MallocAlignment)
 				{
 					shadow_paint_single(ptr, fill);
 				}
@@ -104,12 +105,12 @@ namespace Revocation
 			}
 
 			// First, paint the individual bits at the beginning.
-			for (size_t ptr = base; ptr < baseUp; ptr += MallocAlignment)
+			for (ptraddr_t ptr = base; ptr < baseUp; ptr += MallocAlignment)
 			{
 				shadow_paint_single(ptr, fill);
 			}
 			// Then, paint the aligned shadow words using word instructions.
-			for (size_t ptr = baseUp; ptr < topDown;
+			for (ptraddr_t ptr = baseUp; ptr < topDown;
 			     ptr += ShadowWordSizeBits * MallocAlignment)
 			{
 				size_t capoffset  = (ptr - TCMBaseAddr) >> MallocAlignShift;
@@ -118,7 +119,7 @@ namespace Revocation
 				shadowCap[capoffset >> ShadowWordShift] = shadowWord;
 			}
 			// Finally, paint individual bits at the end.
-			for (size_t ptr = topDown; ptr < top; ptr += MallocAlignment)
+			for (ptraddr_t ptr = topDown; ptr < top; ptr += MallocAlignment)
 			{
 				shadow_paint_single(ptr, fill);
 			}

--- a/sdk/core/allocator/revoker.h
+++ b/sdk/core/allocator/revoker.h
@@ -64,7 +64,7 @@ namespace Revocation
 			              "Address {} is below the TCM base {}",
 			              addr,
 			              TCMBaseAddr);
-			size_t   capoffset  = (addr - TCMBaseAddr) >> MALLOC_ALIGNSHIFT;
+			size_t   capoffset  = (addr - TCMBaseAddr) >> MallocAlignShift;
 			WordT    shadowWord = shadowCap[capoffset >> ShadowWordShift];
 			uint32_t mask       = (1U << (capoffset & ShadowWordMask));
 
@@ -88,7 +88,7 @@ namespace Revocation
 		void shadow_paint_range(size_t base, size_t top, bool fill)
 		{
 			constexpr size_t ShadowWordAddrMask =
-			  (1U << (ShadowWordShift + MALLOC_ALIGNSHIFT)) - 1;
+			  (1U << (ShadowWordShift + MallocAlignShift)) - 1;
 			size_t baseUp  = (base + ShadowWordAddrMask) & ~ShadowWordAddrMask;
 			size_t topDown = top & ~ShadowWordAddrMask;
 
@@ -96,7 +96,7 @@ namespace Revocation
 			// one bit at a time.
 			if (baseUp >= topDown)
 			{
-				for (size_t ptr = base; ptr < top; ptr += MALLOC_ALIGNMENT)
+				for (size_t ptr = base; ptr < top; ptr += MallocAlignment)
 				{
 					shadow_paint_single(ptr, fill);
 				}
@@ -104,21 +104,21 @@ namespace Revocation
 			}
 
 			// First, paint the individual bits at the beginning.
-			for (size_t ptr = base; ptr < baseUp; ptr += MALLOC_ALIGNMENT)
+			for (size_t ptr = base; ptr < baseUp; ptr += MallocAlignment)
 			{
 				shadow_paint_single(ptr, fill);
 			}
 			// Then, paint the aligned shadow words using word instructions.
 			for (size_t ptr = baseUp; ptr < topDown;
-			     ptr += ShadowWordSizeBits * MALLOC_ALIGNMENT)
+			     ptr += ShadowWordSizeBits * MallocAlignment)
 			{
-				size_t capoffset  = (ptr - TCMBaseAddr) >> MALLOC_ALIGNSHIFT;
+				size_t capoffset  = (ptr - TCMBaseAddr) >> MallocAlignShift;
 				WordT  shadowWord = fill ? -1 : 0;
 
 				shadowCap[capoffset >> ShadowWordShift] = shadowWord;
 			}
 			// Finally, paint individual bits at the end.
-			for (size_t ptr = topDown; ptr < top; ptr += MALLOC_ALIGNMENT)
+			for (size_t ptr = topDown; ptr < top; ptr += MallocAlignment)
 			{
 				shadow_paint_single(ptr, fill);
 			}
@@ -127,7 +127,7 @@ namespace Revocation
 		// Return the shadow bit at address addr.
 		bool shadow_bit_get(size_t addr)
 		{
-			size_t   capoffset  = (addr - TCMBaseAddr) >> MALLOC_ALIGNSHIFT;
+			size_t   capoffset  = (addr - TCMBaseAddr) >> MallocAlignShift;
 			WordT    shadowWord = shadowCap[capoffset >> ShadowWordShift];
 			uint32_t mask       = (1U << (capoffset & ShadowWordMask));
 
@@ -145,8 +145,8 @@ namespace Revocation
 		{
 			ptraddr_t base = cap.base();
 
-			return cap.is_valid() && (base & MALLOC_ALIGNMASK) == 0 &&
-			       shadow_bit_get(base - MALLOC_ALIGNMENT) == 1 &&
+			return cap.is_valid() && (base & MallocAlignMask) == 0 &&
+			       shadow_bit_get(base - MallocAlignment) == 1 &&
 			       shadow_bit_get(base) == 0;
 		}
 	};

--- a/sdk/include/ds/bits.h
+++ b/sdk/include/ds/bits.h
@@ -1,0 +1,43 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file Bit manipulation utilities
+ */
+
+#pragma once
+
+#include <concepts>
+
+namespace ds::bits
+{
+
+	/**
+	 * Isolate the least significant set bit.  That is, clear all bits to the
+	 * left of the first set bit.
+	 */
+	template<typename T>
+	__always_inline T isolate_least(T v)
+	{
+		return v & -v;
+	}
+
+	/**
+	 * Mask of all bits above and including the least significant set bit.
+	 */
+	template<typename T>
+	__always_inline T above_or_least(T v)
+	{
+		return v | -v;
+	}
+
+	/**
+	 * Mask of all bits above the least significant set bit.
+	 */
+	template<typename T>
+	__always_inline T above_least(T v)
+	{
+		return above_or_least(v << 1);
+	}
+
+} // namespace ds::bits

--- a/sdk/include/ds/linked_list.h
+++ b/sdk/include/ds/linked_list.h
@@ -1,0 +1,445 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file A (circular) doubly linked list, abstracted over cons cell
+ * representations.
+ */
+
+#pragma once
+
+#include <concepts>
+#include <ds/pointer.h>
+
+namespace ds::linked_list
+{
+
+	namespace cell
+	{
+		/**
+		 * The primitive, required, abstract interface to our cons cells.
+		 *
+		 * All methods are "namespaced" with `cell_` to support the case where
+		 * the encoded forms are also representing other state (for example,
+		 * bit-packed flags in pointer address bits).
+		 */
+		template<typename T>
+		concept HasCellOperations = requires(T &t)
+		{
+			/** Proxies for list linkages */
+			{
+				t.cell_next()
+				} -> ds::pointer::proxy::Proxies<T>;
+			{
+				t.cell_prev()
+				} -> ds::pointer::proxy::Proxies<T>;
+		};
+
+		/**
+		 * Reset a cell to a singleton ring.  Not all cons cells are required to
+		 * be able to do this, though if you're sticking to rings and not
+		 * (ab)using the machinery here in interesting ways, this should be easy
+		 * to specify.
+		 *
+		 * This is a method, and not a constructor, to handle cases where the
+		 * cell is also packing other state into its representation.
+		 */
+		template<typename T>
+		concept HasReset = requires(T &t)
+		{
+			{
+				t.cell_reset()
+				} -> std::same_as<void>;
+		};
+
+		template<typename T>
+		concept HasCellOperationsReset = HasCellOperations<T> && HasReset<T>;
+
+		/**
+		 * Additional, optional overrides available within implementation of
+		 * cons cells.  It may be useful to static_assert() these in
+		 * implementations to make sure we are not falling back to the defaults
+		 * in terms of the above primops.
+		 *
+		 * @{
+		 */
+		template<typename T>
+		concept HasIsSingleton = requires(T &t)
+		{
+			{
+				t.cell_is_singleton()
+				} -> std::same_as<bool>;
+		};
+
+		template<typename T>
+		concept HasIsSingletonCheck = requires(T &t)
+		{
+			{
+				t.cell_is_singleton_check()
+				} -> std::same_as<bool>;
+		};
+
+		template<typename T>
+		concept HasIsDoubleton = requires(T &t)
+		{
+			{
+				t.cell_is_doubleton()
+				} -> std::same_as<bool>;
+		};
+
+		/** @} */
+
+	} // namespace cell
+
+	/**
+	 * Self-loops indicate either the sentinels of an empty list or,
+	 * less often, singletons without their sentinels; it's up to
+	 * the caller to know which is being tested for, here.
+	 *
+	 * The default implementation decodes and compares one link;
+	 * implementations may have more efficient mechanisms.
+	 *
+	 * @{
+	 */
+	template<cell::HasCellOperations T>
+	requires(!cell::HasIsSingleton<T>) __always_inline bool is_singleton(T *e)
+	{
+		return e == e->cell_prev();
+	}
+
+	template<cell::HasCellOperations T>
+	requires(cell::HasIsSingleton<T>) __always_inline bool is_singleton(T *e)
+	{
+		return e->cell_is_singleton();
+	}
+	/** @} */
+
+	/**
+	 * Like is_singleton(), but checks both edges.  Useful only for
+	 * testing invariants.
+	 *
+	 * The default implementation decodes and compares both links.
+	 */
+	template<cell::HasCellOperations T>
+	requires(!cell::HasIsSingletonCheck<T>) __always_inline
+	  bool is_singleton_check(T *e)
+	{
+		return (e == e->cell_next()) && (e == e->cell_prev());
+	}
+
+	template<cell::HasCellOperations T>
+	requires(cell::HasIsSingletonCheck<T>) __always_inline
+	  bool is_singleton_check(T *e)
+	{
+		return e->is_singleton_check();
+	}
+	/** @} */
+
+	/**
+	 * Doubletons are either singleton collections (with both the sentinel
+	 * and the single element satisfying this test) or, less often, a pair
+	 * of elements without a sentinel.  The caller is expected to know
+	 * what's meant by this test.
+	 *
+	 * The default implementation decodes and compares both links.
+	 * @{
+	 */
+	template<cell::HasCellOperations T>
+	requires(!cell::HasIsDoubleton<T>) __always_inline bool is_doubleton(T *e)
+	{
+		return e->cell_prev() == e->cell_next();
+	}
+
+	template<cell::HasCellOperations T>
+	requires(cell::HasIsDoubleton<T>) __always_inline bool is_doubleton(T *e)
+	{
+		return e->cell_is_doubleton();
+	}
+	/** @} */
+
+	/**
+	 * Verify linkage invariants.  Again, useful only for testing.
+	 *
+	 * The default implementation decodes all four relevant links.
+	 */
+	template<cell::HasCellOperations T>
+	__always_inline bool is_well_formed(T *e)
+	{
+		return (e == e->cell_prev()->cell_next()) &&
+		       (e == e->cell_next()->cell_prev());
+	}
+
+	/**
+	 * Insert a ring of `elem`-ents (typically, a singleton ring) before the
+	 * `curr`-ent element (or sentinel) in the ring.  In general, you will
+	 * probably want to make sure that at most one of `elem` or `curr`
+	 * points to a ring with a sentinel node.
+	 *
+	 * If `curr` is the sentinel, this is appending to the list, in the
+	 * sense that the element(s) occupy (or span) the next-most and
+	 * prev-least position from the sentinel.
+	 *
+	 * By symmetry, if `elem` is, instead, the sentinel, then `curr` is
+	 * prepended to the list in the same sense.
+	 */
+	template<cell::HasCellOperations Cell>
+	__always_inline void insert_before(Cell *curr, Cell *elem)
+	{
+		curr->cell_prev()->cell_next() = elem->cell_next();
+		elem->cell_next()->cell_prev() = curr->cell_prev();
+		curr->cell_prev()              = elem;
+		elem->cell_next()              = curr;
+	}
+
+	/**
+	 * Emplacement before.  This fuses initialization and insertion, so that
+	 *
+	 *    emplace_before(c, e);
+	 *
+	 * is semantically equivalent to
+	 *
+	 *    e->cell_reset(); insert_before(c, e);
+	 *
+	 * but spelled in a way that the compiler can understand a bit better, with
+	 * less effort spent in provenance and/or alias analysis.
+	 */
+	template<cell::HasCellOperations Cell, typename P>
+	requires std::same_as<P, Cell *> || ds::pointer::proxy::Proxies<P, Cell>
+	  __always_inline void emplace_before(P curr, Cell *elem)
+	{
+		auto prev         = curr->cell_prev();
+		elem->cell_next() = curr;
+		elem->cell_prev() = prev;
+		prev->cell_next() = elem;
+		prev              = elem;
+	}
+
+	/**
+	 * Emplacement after.  This fuses initialization and insertion, so that
+	 *
+	 *    emplace_after(c, e);
+	 *
+	 * is semantically equivalent to
+	 *
+	 *    e->cell_reset(); insert_before(e, c);
+	 *
+	 * but spelled in a way that the compiler can understand a bit better, with
+	 * less effort spent in provenance and/or alias analysis.
+	 */
+	template<cell::HasCellOperations Cell, typename P>
+	requires std::same_as<P, Cell *> || ds::pointer::proxy::Proxies<P, Cell>
+	  __always_inline void emplace_after(P curr, Cell *elem)
+	{
+		auto next         = curr->cell_next();
+		elem->cell_prev() = curr;
+		elem->cell_next() = next;
+		next->cell_prev() = elem;
+		next              = elem;
+	}
+
+	/**
+	 * Remove from the list without turning the removed span into a
+	 * well-formed ring.  This is useful only if that invariant will be
+	 * restored later (prior to insertion, at the very least).
+	 *
+	 * The removed element or span instead retains links into the ring
+	 * whence it was removed, but is no longer well-formed, since that ring
+	 * no longer references the removed element or span.
+	 *
+	 * This can be used to remove...
+	 *
+	 *   - a single element (`el == er`)
+	 *
+	 *   - the sentinel (`el == er`), leaving the rest of the ring, if any,
+	 *     as a sentinel-free ring
+	 *
+	 *   - a span of elements from `el` to `er` via the `next` links; the
+	 *     removed span is damaged and must be corrected, while the residual
+	 *     ring remains well-formed.
+	 *
+	 * In all cases, `el`'s previous element is returned as a handle to the
+	 * residual ring.
+	 */
+	template<cell::HasCellOperations Cell>
+	__always_inline Cell *unsafe_remove(Cell *el, Cell *er)
+	{
+		auto p         = el->cell_prev();
+		auto n         = er->cell_next();
+		n->cell_prev() = p;
+		p->cell_next() = n;
+		return p;
+	}
+
+	template<cell::HasCellOperations Cell>
+	__always_inline Cell *unsafe_remove(Cell *e)
+	{
+		return unsafe_remove(e, e);
+	}
+
+	/**
+	 * Remove a particular element `rem` from the ring, already knowing its
+	 * adjacent, previous link `prev`.  `prev` remains connected to the ring
+	 * but `rem` will no longer be well-formed.  Returns a proxy to prev's
+	 * next field.
+	 */
+	template<cell::HasCellOperations Cell>
+	__always_inline auto unsafe_remove_link(Cell *prev, Cell *rem)
+	{
+		auto next         = rem->cell_next();
+		auto prevnext     = prev->cell_next();
+		prevnext          = next;
+		next->cell_prev() = prev;
+		return prevnext;
+	}
+
+	/**
+	 * Remove from the ring, cleaving the ring into two well-formed rings.
+	 *
+	 * This can be used to remove...
+	 *
+	 *   - a single element (`el == er`)
+	 *
+	 *   - the sentinel (`el == er`), leaving the rest of the ring, if any,
+	 *     as a sentinel-free collection
+	 *
+	 *   - a span of elements from `el` to `er` via `next` links; the
+	 *     removed span is made into a ring and the residual ring is left
+	 *     well-formed.
+	 *
+	 * In all cases, `el`'s previous element is returned as a handle to the
+	 * residual ring.  (The caller must already have a reference to the span
+	 * being removed).  This is especially useful when `remove`-ing elements
+	 * during a `search`, below: overwriting the callback's Cell pointer
+	 * (passed by *reference*) will continue the iteration, calling back at
+	 * the removed node's successor.
+	 *
+	 * Removing a singleton from its ring from itself causes no change, as
+	 * any would-be residual ring is empty.  This corner case requires some
+	 * care on occasion.
+	 */
+	template<cell::HasCellOperations Cell>
+	__always_inline Cell *remove(Cell *el, Cell *er)
+	{
+		Cell *p         = unsafe_remove(el, er);
+		el->cell_prev() = er;
+		er->cell_next() = el;
+		return p;
+	}
+
+	template<cell::HasCellOperations Cell>
+	__always_inline Cell *remove(Cell *e)
+	{
+		return remove(e, e);
+	}
+
+	/**
+	 * Search through a span of a ring, inclusively from `from` through
+	 * exclusively to `to`, applying `f` to each cons cell in turn.  If `f`
+	 * returns `true`, the search stops early and returns `true`; otherwise,
+	 * search returns `false`.  To (side-effectfully) visit every node in the
+	 * span, have `f` always return false.
+	 */
+	template<cell::HasCellOperations Cell, typename F>
+	__always_inline bool search(Cell *from, Cell *to, F f)
+	{
+		Cell *elem;
+		for (elem = from; elem != to; elem = elem->cell_next())
+		{
+			if (f(elem))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Search through all elements of a ring *except* `elem`.  If `elem` is the
+	 * sentinel of a ring, then this is, as one expects, a `search` over all
+	 * non-sentinel memebers of the ring.
+	 */
+	template<cell::HasCellOperations Cell, typename F>
+	__always_inline bool search(Cell *elem, F f)
+	{
+		return search(static_cast<Cell *>(elem->cell_next()), elem, f);
+	}
+
+	/**
+	 * Convenience wrapper for a sentinel cons cell, encapsulating some common
+	 * patterns.
+	 */
+	template<cell::HasCellOperationsReset CellTemplateArg>
+	struct Sentinel
+	{
+		using Cell = CellTemplateArg;
+
+		/**
+		 * The sentinel node itself.  Viewing the ring as a list, this
+		 * effectively serves as pointers to the head (next) and to the tail
+		 * (prev) of the list.  Unlike more traditional nullptr-terminated
+		 * lists, though, here, the sentinel participates in the ring.
+		 *
+		 * This is marked `cheri_no_subobject_bounds` because some of our cons
+		 * cell implementations use pointer proxies that rely on the bounds
+		 * provided by `this` (which, in turn, is likely to be
+		 * `cheri_no_subobject_bounds`)
+		 */
+		Cell sentinel __attribute__((__cheri_no_subobject_bounds__)) = {};
+
+		__always_inline void reset()
+		{
+			sentinel.cell_reset();
+		}
+
+		__always_inline bool is_empty()
+		{
+			return linked_list::is_singleton(&sentinel);
+		}
+
+		__always_inline void append(Cell *elem)
+		{
+			linked_list::insert_before(&sentinel, elem);
+		}
+
+		__always_inline void append_emplace(Cell *elem)
+		{
+			linked_list::emplace_before(&sentinel, elem);
+		}
+
+		__always_inline void prepend(Cell *elem)
+		{
+			linked_list::insert_before(elem, &sentinel);
+		}
+
+		__always_inline Cell *first()
+		{
+			return sentinel.cell_next();
+		}
+
+		__always_inline Cell *last()
+		{
+			return sentinel.cell_prev();
+		}
+
+		__always_inline Cell *unsafe_take_first()
+		{
+			Cell *f = sentinel.cell_next();
+			linked_list::unsafe_remove_link(&sentinel, f);
+			return f;
+		}
+
+		__always_inline Cell *take_all()
+		{
+			auto p = linked_list::unsafe_remove(&sentinel);
+			sentinel.cell_reset();
+			return p;
+		}
+
+		template<typename F>
+		__always_inline bool search(F f)
+		{
+			return linked_list::search(&sentinel, f);
+		}
+	};
+
+} // namespace ds::linked_list

--- a/sdk/include/ds/pointer.h
+++ b/sdk/include/ds/pointer.h
@@ -1,0 +1,41 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file Pointer utilities
+ */
+
+#pragma once
+
+#include <cheri.hh>
+
+namespace ds::pointer
+{
+
+	/**
+	 * Offset a pointer by a number of bytes.  The return type must be
+	 * explicitly specified by the caller.  The type of the displacement offset
+	 * (Offset) is templated so that we can accept both signed and unsigned
+	 * offsets.
+	 */
+	template<typename T, typename U>
+	static inline __always_inline T *offset(U *base, std::integral auto offset)
+	{
+		CHERI::Capability c{base};
+		c.address() += offset;
+		return c.template cast<void>().template cast<T>();
+	}
+
+	/**
+	 * Compute the unsigned difference in bytes between two pointers' target
+	 * addresses.  To be standards-compliant, cursor must be part of the same
+	 * allocation as base and at a higher address.
+	 */
+	static inline __always_inline size_t diff(const void *base,
+	                                          const void *cursor)
+	{
+		return static_cast<size_t>(reinterpret_cast<const char *>(cursor) -
+		                           reinterpret_cast<const char *>(base));
+	}
+
+} // namespace ds::pointer

--- a/sdk/include/ds/ring_buffer.h
+++ b/sdk/include/ds/ring_buffer.h
@@ -1,0 +1,171 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file Ring/circular buffer state machine.
+ */
+
+#pragma once
+
+#include <cdefs.h>
+#include <type_traits>
+
+namespace ds::ring_buffer
+{
+	/**
+	 * A statically-sized, non-atomic ring buffer state machine.  The actual
+	 * element storage must be provided externally; all this does is manage the
+	 * cursors.  This representation uses an explicit empty flag, rather than
+	 * considering equal cursors to be empty, so as to not need an extra element
+	 * of store Capacity-many items.
+	 *
+	 * The type of the cursors is parametric, but must be unsigned.
+	 *
+	 * The consumer workflow is:
+	 *   - use head_get() to test emptiness and, if nonempty, read the index
+	 *     of the head element
+	 *   - make use of the element in the (external!) storage at that index
+	 *   - call head_advance() to discard the head element
+	 *
+	 * The producer workflow is:
+	 *   - use tail_next() to retrieve the index for the next element,
+	 *     if there is room
+	 *   - populate the element in the (external!) storage at that index
+	 *   - call tail_advance() to make that element available to the
+	 *     consumer
+	 */
+	template<typename Debug, std::size_t Capacity, typename _Ix = std::size_t>
+	class Cursors
+	{
+		static_assert(std::is_arithmetic_v<_Ix> && std::is_unsigned_v<_Ix>,
+		              "Ring buffer cursor type must be unsigned arithmetic");
+
+		template<typename... Args>
+		using Assert = typename Debug::template Assert<Args...>;
+
+		public:
+		using Ix = _Ix;
+
+		private:
+		Ix   head;
+		Ix   tail;
+		bool empty;
+
+		Ix advance(Ix v)
+		{
+			if constexpr ((Capacity & (Capacity - 1)) == 0)
+			{
+				/* For power of two sizes, we can rely on bit masking. */
+				return (v - 1) & (Capacity - 1);
+			}
+			else
+			{
+				/*
+				 * For non-power-of-two, we can use unsigned underflow and
+				 * signed arithmetic right shift to avoid branching.  mask is
+				 * all zeros if next is non-negative and all ones otherwise.
+				 */
+				Ix next   = v - 1;
+				using SIx = std::make_signed_t<Ix>;
+				Ix mask   = static_cast<SIx>(next) >> (8 * sizeof(SIx) - 1);
+				return (mask & (Capacity - 1)) | (~mask & next);
+			}
+		}
+
+		public:
+		/**
+		 * Reset cursors to an empty state.
+		 */
+		void reset()
+		{
+			tail  = 0;
+			head  = advance(tail);
+			empty = true;
+		}
+
+		/**
+		 * Is this ring empty?
+		 */
+		__always_inline bool is_empty()
+		{
+			return empty;
+		}
+
+		/**
+		 * Try to retrieve the head index; returns true if available and
+		 * false otherwise.
+		 */
+		bool head_get(Ix &v)
+		{
+			if (is_empty())
+			{
+				return false;
+			}
+
+			v = head;
+			return true;
+		}
+
+		/**
+		 * Discard the element at the index returned by head_get().
+		 *
+		 * Do not call this unless there was a matching call to
+		 * head_get() that has returned true.
+		 */
+		__always_inline void head_advance()
+		{
+			Assert<>(!empty, "Cannot advance head of empty ring buffer!");
+			if (head == tail)
+			{
+				empty = true;
+			}
+			head = advance(head);
+		}
+
+		/**
+		 * Try to retrieve the index of the tail, if nonempty.
+		 */
+		bool tail_get(Ix &v)
+		{
+			if (is_empty())
+			{
+				return false;
+			}
+
+			v = tail;
+			return true;
+		}
+
+		/**
+		 * Try to retrieve the index beyond the tail, if there is room.
+		 * Returns true and sets the index if so, or returns false if
+		 * not.
+		 */
+
+		bool tail_next(Ix &v)
+		{
+			Ix nt = advance(tail);
+			if (!empty && head == nt)
+			{
+				return false;
+			}
+
+			v = nt;
+			return true;
+		}
+
+		/**
+		 * Make the next element available.
+		 *
+		 * Do not call this unless there was a matching call to
+		 * tail_next() that returned true.
+		 */
+		__always_inline void tail_advance()
+		{
+			Assert<>(empty || head != advance(tail),
+			         "Cannot advance tail of full ring buffer!");
+			tail  = advance(tail);
+			empty = false;
+		}
+	};
+} // namespace ds::ring_buffer

--- a/sdk/include/ds/xoroshiro.h
+++ b/sdk/include/ds/xoroshiro.h
@@ -1,0 +1,138 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+//
+// Imported from snmalloc 4f9d991449380ed7d881a25ba02cc5668c1ff394.
+
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+
+namespace ds::xoroshiro
+{
+	namespace detail
+	{
+
+		/**
+		 * The xoroshiro+ (not ++) generator(s) of Blackman and Vigna's
+		 * Scrambled Linear Pseudorandom Number Generators
+		 * (https://arxiv.org/abs/1805.01407, Figure 1).
+		 *
+		 * This spelling is parameterized on the type of the two state
+		 * variables used internally (State), the type of each sample (Result),
+		 * and the seed state values (A, B, C).
+		 */
+		template<typename State, typename Result, State A, State B, State C>
+		class XorOshiro
+		{
+			private:
+			static constexpr unsigned StateBits  = 8 * sizeof(State);
+			static constexpr unsigned ResultBits = 8 * sizeof(Result);
+
+			static_assert(StateBits >= ResultBits,
+			              "State must have at least as many bits as Result");
+
+			/* Parameters must be valid shifts */
+			static_assert(0 <= A && A <= StateBits);
+			static_assert(0 <= B && B <= StateBits);
+			static_assert(0 <= C && C <= StateBits);
+
+			State x;
+			State y;
+
+			static inline State rotl(State x, State k)
+			{
+				return (x << k) | (x >> (StateBits - k));
+			}
+
+			public:
+			XorOshiro(State x = 5489, State y = 0) : x(x), y(y)
+			{
+				// If both zero, then this does not work
+				if (x == 0 && y == 0)
+					abort();
+
+				next();
+			}
+
+			void set_state(State nx, State ny = 0)
+			{
+				// If both zero, then this does not work
+				if (nx == 0 && ny == 0)
+					abort();
+
+				x = nx;
+				y = ny;
+				next();
+			}
+
+			Result next()
+			{
+				State r = x + y;
+				y ^= x;
+				x = rotl(x, A) ^ y ^ (y << B);
+				y = rotl(y, C);
+				// If both zero, then this does not work
+				if (x == 0 && y == 0)
+					abort();
+				return r >> (StateBits - ResultBits);
+			}
+		};
+	} // namespace detail
+
+	/**
+	 * xoroshiro128+ with 64-bit output using the 2018 parameters.
+	 *
+	 * Parameters from https://prng.di.unimi.it/xoroshiro128plus.c .
+	 */
+	using P128R64 = detail::XorOshiro<uint64_t, uint64_t, 24, 16, 37>;
+
+	/**
+	 * xoroshiro128+ with 32-bit output using the 2018 parameters.
+	 *
+	 * Parameters as per P128R64, above.
+	 */
+	using P128R32 = detail::XorOshiro<uint64_t, uint32_t, 24, 16, 37>;
+
+	/**
+	 * A "xoroshiro64+" with 32-bit outputs.
+	 *
+	 * As per Sebastino Vigna himself, writing in
+	 * https://groups.google.com/g/prng/c/Ll-KDIbpO8k/m/bfHK4FlUCwAJ, these
+	 * parameters are one of may full-period triples.
+	 */
+	using P64R32 = detail::XorOshiro<uint32_t, uint32_t, 27, 7, 20>;
+
+	/**
+	 * A "xoroshiro64+" with 16-bit outputs.
+	 *
+	 * Parameters as per P64R32, above.
+	 */
+	using P64R16 = detail::XorOshiro<uint32_t, uint16_t, 27, 7, 20>;
+
+	/**
+	 * A "xoroshiro32+" with 16-bit outputs.
+	 *
+	 * Parameters as per the Parallax Propeller 2 PRNG (discarding the "++"
+	 * variant's fourth parameter "R").  See
+	 * https://forums.parallax.com/discussion/comment/1448894 .
+	 */
+	using P32R16 = detail::XorOshiro<uint16_t, uint16_t, 13, 5, 10>;
+
+	/**
+	 * A "xoroshiro32+" with 16-bit outputs.
+	 *
+	 * Parameters as per P32R16, above.
+	 */
+	using P32R8 = detail::XorOshiro<uint16_t, uint8_t, 13, 5, 10>;
+
+	/**
+	 * A "xoroshiro16+" with 8-bit outputs.
+	 *
+	 * As per Sebastino Vigna himself, writing in
+	 * https://groups.google.com/g/prng/c/MWJjq11zRis/m/7nM_cwRzAQAJ , the
+	 * parameters are one of may full-period triples, but "There are no good
+	 * 16-bit generators".
+	 */
+	using P16R8 = detail::XorOshiro<uint8_t, uint8_t, 4, 7, 3>;
+} // namespace ds::xoroshiro


### PR DESCRIPTION
I hope that the include/ds files are the kinds of things that might be useful more generally for tiny, embedded systems. The goal here is to offer high-level abstractions without committing to bit-level representations, to some extent mechanizing the semantic gap between diagrams on paper and bit twiddling. I was not aware of an existing library, so I wrote my own; apologies if there's something I should have used instead.

There's still plenty of clean-up possible in the allocator.  In particular, IMHO, it'd be good to get some things on the alloc path more clearly communicating in terms of `MChunkHeader*` / `MChunk*` rather than `void *`s pointing just past the headers.