### PR TITLE
Fix the problem of rebuilding all

### DIFF
--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -200,7 +200,7 @@ rule("firmware")
 		print("loading board description from ", boardfile)
 		local board = json.loadfile(boardfile)
 		local add_defines = function (defines)
-			for _, d in pairs(target:deps()) do
+			for _, d in table.orderpairs(target:deps()) do
 				d:add('defines', defines)
 			end
 		end
@@ -232,7 +232,7 @@ rule("firmware")
 		local mmio_start = 0xffffffff
 		local mmio_end = 0
 		-- Add start and end markers for all MMIO devices.
-		for name, range in pairs(board.devices) do
+		for name, range in table.orderpairs(board.devices) do
 			local start = range.start
 			local stop = range["end"]
 			if not stop then
@@ -445,7 +445,7 @@ rule("firmware")
 		batchcmds:show_progress(opt.progress, "linking firmware " .. target:targetfile())
 		batchcmds:mkdir(target:targetdir())
 		local objects = target:objectfiles()
-		for name, dep in pairs(target:deps()) do
+		for name, dep in table.orderpairs(target:deps()) do
 			if (dep:get("cherimcu.type") == "library") or
 				(dep:get("cherimcu.type") == "compartment") or
 				(dep:get("cherimcu.type") == "privileged compartment") then

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -361,7 +361,7 @@ rule("firmware")
 			local substitute = function (str)
 				return string.gsub(str, "${(%w*)}", { obj=obj, compartment=name })
 			end
-			for key, template in pairs(templates) do
+			for key, template in table.orderpairs(templates) do
 				ldscript_substitutions[key] = ldscript_substitutions[key] .. substitute(template)
 			end
 		end
@@ -409,7 +409,7 @@ rule("firmware")
 
 		-- Process all of the library dependencies.
 		local library_count = 0
-		for name, dep in pairs(target:deps()) do
+		for name, dep in table.orderpairs(target:deps()) do
 			if dep:get("cherimcu.type") == "library" then
 				library_count = library_count + 1
 				add_dependency(name, dep, library_templates)
@@ -418,7 +418,7 @@ rule("firmware")
 
 		-- Process all of the compartment dependencies.
 		local compartment_count = 0
-		for name, dep in pairs(target:deps()) do
+		for name, dep in table.orderpairs(target:deps()) do
 			if dep:get("cherimcu.type") == "compartment" then
 				compartment_count = compartment_count + 1
 				add_dependency(name, dep, compartment_templates)


### PR DESCRIPTION
Since the traversal order of lua's pairs is undefined, the order of the flags list will change randomly each time they are added.

xmake triggers a rebuild based on flags changes, which is not a problem if the list of flags is identical each time it is built.

Also, the xmake/dev branch has a fix for add_configfiles change detection, so that if you use the dev version, no rebuild will be triggered when the code has not changed, even if you switch release/debug mode.

You can run the following command to update to the dev version, which also adds support for ld.lld.

```
xmake update -s dev
```