### PR TITLE
Revert "Update xmake to the latest version in the Dockerfile."

### DIFF
--- a/scripts/devcontainer/Dockerfile
+++ b/scripts/devcontainer/Dockerfile
@@ -8,8 +8,7 @@ RUN apt update \
     && apt install -y software-properties-common \
     && add-apt-repository ppa:xmake-io/xmake \
     && apt update \
-    && apt install -y xmake git clang \
-    && xmake update dev
+    && apt install -y xmake git clang
 
 # Create the user
 RUN useradd -m $USERNAME \

--- a/scripts/devcontainer/Dockerfile
+++ b/scripts/devcontainer/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update \
     && add-apt-repository ppa:xmake-io/xmake \
     && apt update \
     && apt install -y xmake git clang \
-    && xmake update dev --root
+    && xmake update dev
 
 # Create the user
 RUN useradd -m $USERNAME \


### PR DESCRIPTION
This reverts commit f0855be1f94843adb9f5ba18e2fbd6318708ace6.

It looks as if xmake's update command won't update the system-wide installation, which is probably a good idea in general (it shouldn't clobber the files owned by the package manager)