### PR TITLE
Fix .dump generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ $ xmake
 
 This will create the output in `build/cheriot/cheriot/{release,debug}/{name of firmware target}.
 It will also create a `.dump` file in the same location giving the objdump output of the same target.
-*NOTE:* There appears to be an xmake bug where this doesn't always get generated, running `xmake -v` once appears to ensure that it is generated on all subsequent runs.
-
 
 ## Contributing
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -31,7 +31,7 @@ The build system requires a configure step and a build step:
 ```sh
 $ cd tests
 $ xmake config --sdk=/cheriot-tools/
-$ xmake -v
+$ xmake
 ```
 
 To get more verbose output, you can try adding `--debug-{loader,allocator,scheduler}=y` to the `xmake config` flags.

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -454,7 +454,7 @@ rule("firmware")
 		end
 		batchcmds:vrunv(target:tool("ld"), table.join({"--script=" .. linkerscript, "--relax", "-o", target:targetfile()}, objects), opt)
 		batchcmds:show_progress(opt.progress, "Creating firmware dump " .. target:targetfile() .. ".dump")
-		batchcmds:vrunv(target:tool("objdump"), {"-glxsdrS", target:targetfile()}, table.join(opt, {stdout = target:targetfile() .. ".dump"}))
+		batchcmds:vexecv(target:tool("objdump"), {"-glxsdrS", target:targetfile()}, table.join(opt, {stdout = target:targetfile() .. ".dump"}))
 		batchcmds:add_depfiles(linkerscript)
 		batchcmds:add_depfiles(objects)
 	end)


### PR DESCRIPTION
Apparently execv supports it but runv does not.