### PR TITLE
Add a test for a bug in the switcher, alongside a fix

### DIFF
--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -141,7 +141,7 @@ compartment_switcher_entry:
 	cunseal			ct1, ct1, cs0
 	// Make sure the export table is valid
 	cgettag			s0, ct1
-	beqz			s0, .Lforce_unwind_with_return_values
+	beqz			s0, .Linvalid_entry
 	// Load the entry point offset.
 	clhu			s0, ExportEntry_offset_functionStart(ct1)
 	// At this point, we known that the cunseal has succeeded (we didn't trap
@@ -315,9 +315,16 @@ exception_entry_asm:
 	reloadRegisters c1, cgp, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, csp
 	mret
 
-.Lforce_unwind_with_return_values:
-	li		a0, -1
-	li		a1, 0
+.Linvalid_entry:
+// Mark this threads as in the middle of a forced unwind.
+	li             a0, 1
+	csb            a0, TrustedStack_offset_inForcedUnwind(ctp)
+// Make sure we don't leak anything to the compartment.
+// Registers might been used by the call and therefore need zeroing.
+	zeroAllRegistersExcept a0, s0, s1, sp, a2, gp
+// Store an error value in return registers, which will be passed to the
+// caller on unwind. a0 is zeroed by zeroAllRegistersExcept 
+	li          a0, -1
 // We are starting a forced unwind.  This is reached either when we are unable
 // to run an error handler, or when we do run an error handler and it instructs
 // us to return.  This treats all register values as undefined on entry.

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -137,8 +137,12 @@ compartment_switcher_entry:
 	LoadCapPCC		cs0, compartment_switcher_sealing_key
 	li				gp, 9
 	csetaddr		cs0, cs0, gp
-	// The target capability is in ct1. Unseal and load the entry point offset.
+	// The target capability is in ct1. Unseal, check tag and load the entry point offset.
 	cunseal			ct1, ct1, cs0
+	// Make sure the export table is valid
+	cgettag			s0, ct1
+	beqz			s0, .Lforce_unwind_with_return_values
+	// Load the entry point offset.
 	clhu			s0, ExportEntry_offset_functionStart(ct1)
 	// At this point, we known that the cunseal has succeeded (we didn't trap
 	// on the load) and so it's safe to store the unsealed value of the export
@@ -311,6 +315,9 @@ exception_entry_asm:
 	reloadRegisters c1, cgp, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, csp
 	mret
 
+.Lforce_unwind_with_return_values:
+	li		a0, -1
+	li		a1, 0
 // We are starting a forced unwind.  This is reached either when we are unable
 // to run an error handler, or when we do run an error handler and it instructs
 // us to return.  This treats all register values as undefined on entry.

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -315,6 +315,8 @@ exception_entry_asm:
 	reloadRegisters c1, cgp, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, csp
 	mret
 
+// If we detect an invalud entry and there is no error handler installed, we want
+// to resume rather than unwind.
 .Linvalid_entry:
 // Mark this threads as in the middle of a forced unwind.
 	li             a0, 1
@@ -332,9 +334,6 @@ exception_entry_asm:
 	// Pop the trusted stack frame.
 	cjal           .Lpop_trusted_stack_frame
 	cmove          cra, ca2
-// At this point, cra should contain the return address, ca0 and ca1 to contain
-// the return values, cs0, cs1, cgp and csp to contain the values from the
-// caller.  All other registers will be cleared before return.
 .Lout_of_trusted_stack:
 	cmove          ct0, csp
 	// Fetch the trusted stack pointer.
@@ -350,10 +349,10 @@ exception_entry_asm:
 	LoadCapPCC     cs0, compartment_switcher_sealing_key
 	// ca2 at this point was loaded by .Lpop_trusted_stack_frame from the pcc
 	// in the trusted stack and so should always be sealed as a sentry type.
-	cgettype       gp, cra
+	cgettype       gp, ca2
 	csetaddr       cs0, cs0, gp
-	cunseal        cra, cra, cs0
-	csc            cra, TrustedStack_offset_mepcc(csp)
+	cunseal        ca2, ca2, cs0
+	csc            ca2, TrustedStack_offset_mepcc(csp)
 	clw            t0, TrustedStack_offset_mstatus(csp)
 	// If gp==2 then the we need to disable interrupts on return, otherwise we
 	// need to enable them.  The interrupt enable bit is bit 7.  We want to set

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -349,10 +349,10 @@ exception_entry_asm:
 	LoadCapPCC     cs0, compartment_switcher_sealing_key
 	// ca2 at this point was loaded by .Lpop_trusted_stack_frame from the pcc
 	// in the trusted stack and so should always be sealed as a sentry type.
-	cgettype       gp, ca2
+	cgettype       gp, cra
 	csetaddr       cs0, cs0, gp
-	cunseal        ca2, ca2, cs0
-	csc            ca2, TrustedStack_offset_mepcc(csp)
+	cunseal        cra, cra, cs0
+	csc            cra, TrustedStack_offset_mepcc(csp)
 	clw            t0, TrustedStack_offset_mstatus(csp)
 	// If gp==2 then the we need to disable interrupts on return, otherwise we
 	// need to enable them.  The interrupt enable bit is bit 7.  We want to set

--- a/tests/compartment_calls-test.cc
+++ b/tests/compartment_calls-test.cc
@@ -43,6 +43,14 @@ void test_number_of_arguments()
 
 void test_compartment_call()
 {
+	bool outTestFailed = false;
+	int ret = 0;
+
 	test_number_of_arguments();
-	test_incorrect_export_table(NULL);
+	ret = test_incorrect_export_table_with_handler(nullptr);
+	TEST(ret == -1, "Test incorrect entry point with error handler failed");
+
+	ret = test_incorrect_export_table(nullptr, &outTestFailed);
+	TEST(outTestFailed == false,
+	     "Test incorrect entry point without error handler failed");
 }

--- a/tests/compartment_calls-test.cc
+++ b/tests/compartment_calls-test.cc
@@ -9,7 +9,7 @@
 
 using namespace CHERI;
 
-void test_compartment_call()
+void test_number_of_arguments()
 {
 	debug_log(
 	  "Test argument calls with different number and type of arguments");
@@ -39,4 +39,10 @@ void test_compartment_call()
 	ret =
 	  compartment_call_inner(value, value, &value, value, &value, value, value);
 	TEST(ret == 0, "compartment_call_inner returend {}", ret);
+}
+
+void test_compartment_call()
+{
+	test_number_of_arguments();
+	test_incorrect_export_table(NULL);
 }

--- a/tests/compartment_calls-test.cc
+++ b/tests/compartment_calls-test.cc
@@ -44,7 +44,7 @@ void test_number_of_arguments()
 void test_compartment_call()
 {
 	bool outTestFailed = false;
-	int ret = 0;
+	int  ret           = 0;
 
 	test_number_of_arguments();
 	ret = test_incorrect_export_table_with_handler(nullptr);

--- a/tests/compartment_calls.h
+++ b/tests/compartment_calls.h
@@ -38,6 +38,8 @@ __cheri_compartment("compartment_calls_inner") int compartment_call_inner(
   const int *x4,
   int        x5,
   int        x6);
+__cheri_compartment("compartment_calls_inner") void test_incorrect_export_table(
+  __cheri_callback void (*fn)());
 __cheri_compartment("compartment_calls_outer") void compartment_call_outer();
 
 constexpr int ConstantValue = 0x41414141;

--- a/tests/compartment_calls.h
+++ b/tests/compartment_calls.h
@@ -41,8 +41,8 @@ __cheri_compartment("compartment_calls_inner") int compartment_call_inner(
 __cheri_compartment("compartment_calls_inner") int test_incorrect_export_table(
   __cheri_callback void (*fn)(),
   bool *outTestFailed);
-__cheri_compartment("compartment_calls_inner_with_"
-                    "handler") int test_incorrect_export_table_with_handler(
-  __cheri_callback void (*fn)());
+__cheri_compartment(
+  "compartment_calls_inner_with_"
+  "handler") int test_incorrect_export_table_with_handler(__cheri_callback void (*fn)());
 __cheri_compartment("compartment_calls_outer") void compartment_call_outer();
 constexpr int ConstantValue = 0x41414141;

--- a/tests/compartment_calls.h
+++ b/tests/compartment_calls.h
@@ -38,8 +38,11 @@ __cheri_compartment("compartment_calls_inner") int compartment_call_inner(
   const int *x4,
   int        x5,
   int        x6);
-__cheri_compartment("compartment_calls_inner") void test_incorrect_export_table(
+__cheri_compartment("compartment_calls_inner") int test_incorrect_export_table(
+  __cheri_callback void (*fn)(),
+  bool *outTestFailed);
+__cheri_compartment("compartment_calls_inner_with_"
+                    "handler") int test_incorrect_export_table_with_handler(
   __cheri_callback void (*fn)());
 __cheri_compartment("compartment_calls_outer") void compartment_call_outer();
-
 constexpr int ConstantValue = 0x41414141;

--- a/tests/compartment_calls_inner.cc
+++ b/tests/compartment_calls_inner.cc
@@ -98,7 +98,7 @@ int compartment_call_inner(int        x0,
 }
 
 int test_incorrect_export_table(__cheri_callback void (*fn)(),
-                                 bool *outTestFailed)
+                                bool *outTestFailed)
 {
 	/*
 	 * Trigger a cross-compartment call with an invalid export entry.

--- a/tests/compartment_calls_inner.cc
+++ b/tests/compartment_calls_inner.cc
@@ -10,12 +10,6 @@
 
 using namespace CHERI;
 
-extern "C" ErrorRecoveryBehaviour
-compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval)
-{
-	return ErrorRecoveryBehaviour::ForceUnwind;
-}
-
 std::tuple expectedArguments = {ConstantValue,
                                 ConstantValue,
                                 ConstantValue,
@@ -103,7 +97,8 @@ int compartment_call_inner(int        x0,
 	return 0;
 }
 
-void test_incorrect_export_table(__cheri_callback void (*fn)())
+int test_incorrect_export_table(__cheri_callback void (*fn)(),
+                                 bool *outTestFailed)
 {
 	/*
 	 * Trigger a cross-compartment call with an invalid export entry.
@@ -111,7 +106,10 @@ void test_incorrect_export_table(__cheri_callback void (*fn)())
 
 	debug_log("test an incorrect export table entry");
 
+	*outTestFailed = true;
+
 	fn();
 
-	TEST(false, "Should be unreachable");
+	*outTestFailed = false;
+	return 0;
 }

--- a/tests/compartment_calls_inner.cc
+++ b/tests/compartment_calls_inner.cc
@@ -10,6 +10,12 @@
 
 using namespace CHERI;
 
+extern "C" ErrorRecoveryBehaviour
+compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval)
+{
+	return ErrorRecoveryBehaviour::ForceUnwind;
+}
+
 std::tuple expectedArguments = {ConstantValue,
                                 ConstantValue,
                                 ConstantValue,
@@ -95,4 +101,17 @@ int compartment_call_inner(int        x0,
 	debug_log("Seven arguments");
 	verify_arguments(x0, x1, *x2, x3, *x4, x5, x6);
 	return 0;
+}
+
+void test_incorrect_export_table(__cheri_callback void (*fn)())
+{
+	/*
+	 * Trigger a cross-compartment call with an invalid export entry.
+	 */
+
+	debug_log("test an incorrect export table entry");
+
+	fn();
+
+	TEST(false, "Should be unreachable");
 }

--- a/tests/compartment_calls_inner_with_handler.cc
+++ b/tests/compartment_calls_inner_with_handler.cc
@@ -1,0 +1,31 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#define TEST_NAME "Compartment calls (inner compartment)"
+#include "compartment_calls.h"
+#include "tests.hh"
+#include <cheri.hh>
+#include <errno.h>
+#include <tuple>
+
+using namespace CHERI;
+
+extern "C" ErrorRecoveryBehaviour
+compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval)
+{
+	return ErrorRecoveryBehaviour::ForceUnwind;
+}
+
+void test_incorrect_export_table_with_handler(__cheri_callback void (*fn)())
+{
+	/*
+	 * Trigger a cross-compartment call with an invalid export entry.
+	 */
+
+	debug_log(
+	  "test an incorrect export table entry with error handler installed");
+
+	fn();
+
+	TEST(false, "Should be unreachable");
+}

--- a/tests/compartment_calls_inner_with_handler.cc
+++ b/tests/compartment_calls_inner_with_handler.cc
@@ -16,7 +16,7 @@ compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval)
 	return ErrorRecoveryBehaviour::ForceUnwind;
 }
 
-void test_incorrect_export_table_with_handler(__cheri_callback void (*fn)())
+int test_incorrect_export_table_with_handler(__cheri_callback void (*fn)())
 {
 	/*
 	 * Trigger a cross-compartment call with an invalid export entry.
@@ -28,4 +28,6 @@ void test_incorrect_export_table_with_handler(__cheri_callback void (*fn)())
 	fn();
 
 	TEST(false, "Should be unreachable");
+
+	return 0;
 }

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -50,6 +50,8 @@ compartment("stack_exhaustion_thread")
 test("stack_exhaustion")
 compartment("compartment_calls_inner")
     add_files("compartment_calls_inner.cc")
+compartment("compartment_calls_inner_with_handler")
+    add_files("compartment_calls_inner_with_handler.cc")
 test("compartment_calls")
 
 includes(path.join(sdkdir, "lib/atomic"),
@@ -79,7 +81,7 @@ firmware("test-suite")
     add_deps("multiwaiter_test")
     add_deps("ccompile_test")
     add_deps("stack_exhaustion_test", "stack_exhaustion_trusted", "stack_exhaustion_thread")
-    add_deps("compartment_calls_test", "compartment_calls_inner")
+    add_deps("compartment_calls_test", "compartment_calls_inner", "compartment_calls_inner_with_handler")
     -- Set the thread entry point to the test runner.
     on_load(function(target)
         target:values_set("board", "$(board)")


### PR DESCRIPTION
The switcher does not check the validity of the target entry point. Add a check for that and implement a test.