### PR TITLE
Implement precise checking of free(mem)

### DIFF
--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -215,15 +215,11 @@ namespace
 	{
 		return -EINVAL;
 	}
-	/*
-	 * Since we use the shadow bits to detect valid frees, we need to consult
-	 * the revoker on whether the user cap is valid.
-	 */
-	if (!revoker.is_free_cap_valid(mem))
+	int rv = gm->mspace_free(mem);
+	if (rv)
 	{
-		return -EINVAL;
+		return rv;
 	}
-	gm->mspace_free(mem);
 
 	// If there are any threads blocked allocating memory, wake them up.
 	if (freeFutex > 0)

--- a/sdk/include/cheri.hh
+++ b/sdk/include/cheri.hh
@@ -844,6 +844,11 @@ namespace CHERI
 			return std::partial_ordering::unordered;
 		}
 
+		constexpr bool operator==(const Capability Other) const
+		{
+			return __builtin_cheri_equal_exact(ptr, Other.ptr);
+		}
+
 		/**
 		 * Capability comparison.  Defines ordered comparison for capabilities
 		 * with the same bounds and permissions.  All other capabilities are
@@ -1001,6 +1006,13 @@ namespace CHERI
 	__always_inline inline size_t representable_alignment_mask(size_t length)
 	{
 		return __builtin_cheri_representable_alignment_mask(length);
+	}
+
+	/// Can the range [base, base + size) be precisely covered by a capability?
+	inline bool is_precise_range(ptraddr_t base, size_t size)
+	{
+		return (base & ~representable_alignment_mask(size)) == 0 &&
+		       representable_length(size) == size;
 	}
 
 	namespace detail

--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -169,7 +169,7 @@ namespace
 	{
 		static constexpr size_t MaxAllocs    = 256;
 		static constexpr size_t AllocSizes[] = {
-		  16, 64, 72, 96, 128, 256, 348, 1024};
+		  16, 64, 72, 96, 128, 256, 384, 1024};
 		static constexpr size_t NAllocSizes = std::size(AllocSizes);
 
 		ds::xoroshiro::P32R16 rand = {};
@@ -180,7 +180,10 @@ namespace
 
 			if (p != nullptr)
 			{
-				TEST(CHERI::Capability{p}.length() == sz, "Bad return length");
+				CHERI::Capability pwrap{p};
+				// dlmalloc can give you one granule more.
+				TEST(pwrap.length() == sz || pwrap.length() == sz + 8,
+				     "Bad return length");
 				memset(p, 0xCA, sz);
 				allocations.push_back(p);
 			}


### PR DESCRIPTION
We used to only check that cgetbase(mem) is correct. We harden free so that mem needs to be exactly equal to what the user got on malloc(). If there are missing permissions, different bounds and addresses, it is likely a bug from the user.

To implement this, a couple of things need to change:
1. The setbounds in malloc() needs at least capability alignment.
2. On malloc(size), if the returned chunk can be precisely covered by a capability, then always use the whole chunk.
3. If not, use the portion that can be precise, which shares the base with the whole chunk and is exactly MChunkAlignment smaller than the whole thing. If it is >= 2*MChunkAlignment smaller, then we must have split it into two chunks so this cannot happen.