### PR TITLE
Use a lock to protect the allocator.

### DIFF
--- a/examples/01.hello_world/xmake.lua
+++ b/examples/01.hello_world/xmake.lua
@@ -8,6 +8,7 @@ set_toolchains("cheriot-clang")
 
 -- Support libraries
 includes(path.join(sdkdir, "lib/freestanding"),
+         path.join(sdkdir, "lib/atomic"),
          path.join(sdkdir, "lib/crt"))
 
 option("board")
@@ -18,7 +19,7 @@ compartment("hello")
 
 -- Firmware image for the example.
 firmware("hello_world")
-    add_deps("crt", "freestanding")
+    add_deps("crt", "freestanding", "atomic_fixed")
     add_deps("hello")
     on_load(function(target)
         target:values_set("board", "$(board)")

--- a/examples/02.hello_compartment/xmake.lua
+++ b/examples/02.hello_compartment/xmake.lua
@@ -8,6 +8,7 @@ set_toolchains("cheriot-clang")
 
 -- Support libraries
 includes(path.join(sdkdir, "lib/freestanding"),
+         path.join(sdkdir, "lib/atomic"),
          path.join(sdkdir, "lib/crt"))
 
 
@@ -22,7 +23,7 @@ compartment("hello")
 
 -- Firmware image for the example.
 firmware("hello_compartment")
-    add_deps("crt", "freestanding")
+    add_deps("crt", "freestanding", "atomic_fixed")
     add_deps("hello", "uart")
     on_load(function(target)
         target:values_set("board", "$(board)")

--- a/examples/03.hello_safe_compartment/xmake.lua
+++ b/examples/03.hello_safe_compartment/xmake.lua
@@ -8,6 +8,7 @@ set_toolchains("cheriot-clang")
 
 -- Support libraries
 includes(path.join(sdkdir, "lib/freestanding"),
+         path.join(sdkdir, "lib/atomic"),
          path.join(sdkdir, "lib/crt"))
 
 option("board")
@@ -21,7 +22,7 @@ compartment("hello")
 
 -- Firmware image for the example.
 firmware("hello_safe_compartment")
-    add_deps("crt", "freestanding")
+    add_deps("crt", "freestanding", "atomic_fixed")
     add_deps("hello", "uart")
     on_load(function(target)
         target:values_set("board", "$(board)")

--- a/examples/04.temporal_safety/xmake.lua
+++ b/examples/04.temporal_safety/xmake.lua
@@ -8,6 +8,7 @@ set_toolchains("cheriot-clang")
 
 -- Support libraries
 includes(path.join(sdkdir, "lib/freestanding"),
+         path.join(sdkdir, "lib/atomic"),
          path.join(sdkdir, "lib/crt"))
 
 option("board")
@@ -18,7 +19,7 @@ compartment("allocate")
 
 -- Firmware image for the example.
 firmware("temporal_safety")
-    add_deps("crt", "freestanding")
+    add_deps("crt", "freestanding", "atomic_fixed")
     add_deps("allocate")
     on_load(function(target)
         target:values_set("board", "$(board)")

--- a/examples/06.producer-consumer/xmake.lua
+++ b/examples/06.producer-consumer/xmake.lua
@@ -8,6 +8,7 @@ set_toolchains("cheriot-clang")
 
 -- Support libraries
 includes(path.join(sdkdir, "lib/freestanding"),
+         path.join(sdkdir, "lib/atomic"),
          path.join(sdkdir, "lib/crt"))
 
 option("board")
@@ -21,7 +22,7 @@ compartment("consumer")
 
 -- Firmware image for the example.
 firmware("producer-consumer")
-    add_deps("crt", "freestanding")
+    add_deps("crt", "freestanding", "atomic_fixed")
     add_deps("producer", "consumer")
     on_load(function(target)
         target:values_set("board", "$(board)")

--- a/examples/08.memory_safety/xmake.lua
+++ b/examples/08.memory_safety/xmake.lua
@@ -19,7 +19,7 @@ compartment("memory_safety_runner")
 
 -- Firmware image for the example.
 firmware("memory_safety")
-    add_deps("crt", "freestanding")
+    add_deps("crt", "freestanding", "atomic_fixed")
     add_deps("memory_safety_runner", "memory_safety_inner")
     on_load(function(target)
         target:values_set("board", "$(board)")

--- a/examples/09.javascript/xmake.lua
+++ b/examples/09.javascript/xmake.lua
@@ -9,6 +9,7 @@ set_toolchains("cheriot-clang")
 -- Support libraries
 includes(path.join(sdkdir, "lib/freestanding"),
          path.join(sdkdir, "lib/string"),
+         path.join(sdkdir, "lib/atomic"),
          path.join(sdkdir, "lib/microvium"),
          path.join(sdkdir, "lib/crt"))
 
@@ -20,7 +21,7 @@ compartment("hello")
 
 -- Firmware image for the example.
 firmware("javascript")
-    add_deps("crt", "freestanding", "string", "microvium")
+    add_deps("crt", "freestanding", "string", "microvium", "atomic_fixed")
     add_deps("hello")
     on_load(function(target)
         target:values_set("board", "$(board)")

--- a/sdk/include/token.h
+++ b/sdk/include/token.h
@@ -35,8 +35,7 @@ __BEGIN_DECLS
  * If the sealing keys have been exhausted then this will return
  * `INVALID_SKEY`.  This API is guaranteed never to block.
  */
-[[cheri::interrupt_state(disabled)]] SKey __cheri_compartment("alloc")
-  token_key_new(void);
+SKey __cheri_compartment("alloc") token_key_new(void);
 
 /**
  * Allocate a new object with size `sz`.
@@ -49,7 +48,7 @@ __BEGIN_DECLS
  *
  * On error, this returns `INVALID_SOBJ`.
  */
-[[cheri::interrupt_state(disabled)]] SObj __cheri_compartment("alloc")
+SObj __cheri_compartment("alloc")
   token_sealed_unsealed_alloc(SKey key, size_t sz, void **unsealed);
 
 /**
@@ -58,8 +57,7 @@ __BEGIN_DECLS
  *
  * The key must have the permit-seal permission.
  */
-[[cheri::interrupt_state(disabled)]] SObj __cheri_compartment("alloc")
-  token_sealed_alloc(SKey, size_t);
+SObj __cheri_compartment("alloc") token_sealed_alloc(SKey, size_t);
 
 /**
  * Unseal the obj given the key.
@@ -69,8 +67,7 @@ __BEGIN_DECLS
  * @return unsealed obj if key and obj are valid and they match. nullptr
  * otherwise
  */
-[[cheri::interrupt_state(disabled)]] void *__cheri_compartment("alloc")
-  token_obj_unseal(SKey, SObj);
+void *__cheri_compartment("alloc") token_obj_unseal(SKey, SObj);
 
 /**
  * Destroy the obj given its key, freeing memory.
@@ -80,8 +77,7 @@ __BEGIN_DECLS
  * @return 0 if no errors. -EINVAL if key or obj not valid, or they don't
  * match, or double destroy.
  */
-[[cheri::interrupt_state(disabled)]] int __cheri_compartment("alloc")
-  token_obj_destroy(SKey, SObj);
+int __cheri_compartment("alloc") token_obj_destroy(SKey, SObj);
 
 __END_DECLS
 

--- a/sdk/lib/atomic/README.md
+++ b/sdk/lib/atomic/README.md
@@ -9,7 +9,7 @@ The `atomicn.cc` file provides support for arbitrary-width operations.
 
 A lot of systems are likely to need only a subset of these operations.
 You can provide subsets of these in three different ways.
-First, you can depend on the `atomic-fixed` target rather than `atomic`.
+First, you can depend on the `atomic_fixed` target rather than `atomic`.
 This excludes the variable-width atomics, which are required by C11 / C++11 but which are rarely used.
 
 If you know that you are using atomics only of a single size, you can define your own library target that specifies a custom subset of the files.

--- a/sdk/lib/atomic/xmake.lua
+++ b/sdk/lib/atomic/xmake.lua
@@ -2,13 +2,15 @@
 -- SPDX-License-Identifier: MIT
 
 library("atomic")
+  set_default(false)
   add_files("atomic1.cc",
             "atomic2.cc",
             "atomic4.cc",
             "atomic8.cc",
             "atomicn.cc")
 
-library("atomic-fixed")
+library("atomic_fixed")
+  set_default(false)
   add_files("atomic1.cc",
             "atomic2.cc",
             "atomic4.cc",


### PR DESCRIPTION
The allocator initially ran with interrupts disabled. This allowed a slow allocation to prevent a realtime thread from making progress for quite a long time.  The new version ensures that the allocator is preemptible for almost all of its lifetime.

This does introduce a potential priority inheritance problem.  Consider three threads, A, B, C, in descending order of priority:

1. C begins freeing memory and is preempted
2. A begins allocating and blocks, waiting for C.
3. B runs without yielding.

Because B never yields, C is never scheduled and A is never able to make progress.  This can be fixed by adding a priority-propagating futex, which will be a future commit.