### PR TITLE
Generate the compartment report when linking.

### DIFF
--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -461,7 +461,8 @@ rule("firmware")
 				table.insert(objects, dep:targetfile())
 			end
 		end
-		batchcmds:vrunv(target:tool("ld"), table.join({"--script=" .. linkerscript, "--relax", "-o", target:targetfile()}, objects), opt)
+		batchcmds:vrunv(target:tool("ld"), table.join({"--script=" .. linkerscript, "--relax", "-o", target:targetfile(), "--compartment-report=" .. target:targetfile() .. ".json" }, objects), opt)
+		batchcmds:show_progress(opt.progress, "Creating firmware report " .. target:targetfile() .. ".json")
 		batchcmds:show_progress(opt.progress, "Creating firmware dump " .. target:targetfile() .. ".dump")
 		batchcmds:vexecv(target:tool("objdump"), {"-glxsdrS", target:targetfile()}, table.join(opt, {stdout = target:targetfile() .. ".dump"}))
 		batchcmds:add_depfiles(linkerscript)


### PR DESCRIPTION
Now that the linker generates something useful, enable the flag by default.