### PR TITLE
RISC-V reentrant exceptions handling

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ It has two main entry points, one that is triggered on interrupt delivery and on
 The majority of the switcher runs with interrupts disabled, to simplify auditing.
 
 The switcher runs with the access-system-registers permission.
-It uses this permission to store a capability to the current thread's trusted stack and register-save area in the `mscratchc` capability special register (CSR).
+It uses this permission to store a capability to the current thread's trusted stack and register-save area in the `mtdc` capability special register (CSR).
 
 On interrupt, the switcher is responsible for saving the register state and invoking the scheduler with a sealed capability to the register save area and trusted stack.
 On cross-compartment call, the switcher is responsible for unsealing the target, shrinking the stack to include only the unused parts, clearing the stack, setting up the new entry on the trusted stack.

--- a/sdk/core/loader/boot.S
+++ b/sdk/core/loader/boot.S
@@ -32,12 +32,12 @@ start:
 
 	la_abs			a3, bootStack
 	li				a1, BOOT_STACK_SIZE
-	cspecialr		ca2, mtdc
-	li				a4, ~CHERI_PERM_STORE_LOCAL
+	cspecialr		ca4, mtdc // Keep the RW memory root in ca4 throughout
+	li				a2, ~CHERI_PERM_STORE_LOCAL
 	li				a5, ~CHERI_PERM_GLOBAL
-	// Keep G in ca4 and SL in ca5.
-	candperm		ca4, ca2, a4
-	candperm		ca5, ca2, a5
+	// Keep G in ca2 and SL in ca5.
+	candperm		ca2, ca4, a2
+	candperm		ca5, ca4, a5
 	csetaddr		csp, ca5, a3
 	csetboundsexact	csp, csp, a1
 	cincoffset		csp, csp, a1 // Move to the end and grow downwards.
@@ -45,17 +45,17 @@ start:
 	// Prepare a trusted stack for the loader.
 	la_abs			a3, bootTStack
 	li				a1, BOOT_TSTACK_SIZE
-	csetaddr        ca3, ca2, a3 // ca2 has the RW root
+	csetaddr		ca3, ca4, a3 // ca4 still has the RW (G+SL!) root
 	csetboundsexact	ca3, ca3, a1
 	li				a1, TSTACKOFFSET_FIRSTFRAME
 	csh				a1, TrustedStack_offset_frameoffset(ca3)
-	cspecialrw		ctp, mscratchc, ca3
+	cspecialw		mtdc, ca3
 
 	// Prepare a bounded pointer to the header.
-	la_abs			a2, __compart_headers
+	la_abs			a1, __compart_headers
 	la_abs			a3, __compart_headers_end
-	sub				a3, a3, a2
-	csetaddr		ca1, ca4, a2 // ca4 has the G root.
+	sub				a3, a3, a1
+	csetaddr		ca1, ca2, a1 // ca2 still has the G root.
 	csetboundsexact	ca1, ca1, a3
 	// Set up $cra to be the loader's C++ entry point.
 	// We are safe to clobber $cra here because this is the root function on
@@ -90,13 +90,13 @@ start:
 	cincoffset		cgp, cgp, s1
 
 	// We just want to grab the EXE root. Offset in auipcc matters not.
-	auipcc          ca2, 0
+	auipcc			ca2, 0
 	cgetbase		t1, ca2
 	csetaddr		ca2, ca2, t1
-	// ctp still has the sealing root.
-	cmove			ca3, ctp
-	// mtdc still has the memory root.
-	cspecialr		ca4, mtdc
+	// mscratchc still has the sealing root; take it and stash the RW root
+	cmove			ca3, ca4
+	cspecialrw		ca3, mscratchc, ca3
+	// ca4 still has the RW memory root; nothing to change
 	// The return value is SchedEntryInfo.
 	cincoffset		csp, csp, -16 - CONFIG_THREADS_NUM * BOOT_THREADINFO_SZ
 	csetbounds		ca0, csp, 16 + CONFIG_THREADS_NUM * BOOT_THREADINFO_SZ
@@ -117,15 +117,17 @@ start:
 	// Nothing in the loader stores to the stack after this point
 
 	// Zero the entire heap and clear roots.
-	cspecialr		ca0, mtdc // RW root is still in MTDC.
+	cspecialr		ca0, mscratchc // RW root temporarily held here
 	la_abs			a1, __export_mem_heap
 	csetaddr		ca0, ca0, a1
 	la_abs			a1, __export_mem_heap_end
 	cjal			.Lfill_block
-	// Clear the roots.
+	// Clear the remaining roots.
+	// mtdc is serving its purpose since being set above, and mtcc
+	// has been set by the loader_entry_point.
 	zeroOne			a0
 	cspecialw		mepcc, ca0
-	cspecialw		mtdc, ca0
+	cspecialw		mscratchc, ca0
 
 	// Move the scheduler's PCC into the register we'll jump to later.
 	cmove			cra, cs0

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -279,16 +279,14 @@ exception_entry_asm:
 	// Function signature of the scheduler entry point:
 	// TrustedStack *exception_entry(TrustedStack *sealedTStack,
 	//     size_t mcause, size_t mepc, size_t mtval)
-	cmove              ca0, csp
-	mv                 a1, t1
-	cgetaddr           a2, ct0
-	csrr               a3, mtval
-	// Fetch the sealing key and set the type that we'll use to our data
-	// sealing type.
+
 	LoadCapPCC         ca5, compartment_switcher_sealing_key
 	li                 gp, 10
 	csetaddr           ca5, ca5, gp
-	cseal              ca0, ca0, ca5
+	cseal              ca0, csp, ca5 // sealed trusted stack
+	mv                 a1, t1 // mcause
+	cgetaddr           a2, ct0 // mepcc address
+	csrr               a3, mtval
 	// Fetch the stack, cgp and the trusted stack for the scheduler.
 	LoadCapPCC         csp, switcher_scheduler_entry_csp
 	LoadCapPCC         cgp, switcher_scheduler_entry_cgp

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -106,10 +106,10 @@ compartment_switcher_entry:
 	// compartment's csp is valid. If not, force unwind.
 	check_compartment_stack_integrity csp
 	// The caller should back up all callee saved registers.
-	// mscratchc should always have an offset of 0.
-	cspecialr          ct2, mscratchc
+	// mtdc should always have an offset of 0.
+	cspecialr          ct2, mtdc
 #ifndef NDEBUG
-	// XXX: This line is useless, only for mscratch to show up in debugging.
+	// XXX: This line is useless, only for mtdc to show up in debugging.
 	cmove              ct2, ct2
 #endif
 
@@ -118,7 +118,7 @@ compartment_switcher_entry:
 	cgetlen            t2, ct2
 	bgeu               tp, t2, .Lout_of_trusted_stack
 	// we are past the stacks checks. Reload ct2; tp is still as it was
-	cspecialr          ct2, mscratchc
+	cspecialr          ct2, mtdc
 	// ctp points to the current available trusted stack frame.
 	cincoffset         ctp, ct2, tp
 	csc                cra, TrustedStackFrame_offset_pcc(ctp)
@@ -237,14 +237,16 @@ compartment_switcher_entry:
 exception_entry_asm:
 	// We do not trust the interruptee's context. We cannot use its stack in any way.
 	// The save reg frame we can use is fetched from the tStack.
-	// mscratchc plays the trusted stack register role now. We may want to change that.
-	cspecialrw         csp, mscratchc, csp
+	// In general, mtdc holds the trusted stack register.  We are here with
+	// interrupts off and precious few registers available to us, so swap it
+	// with the csp (we'll put it back, later).
+	cspecialrw         csp, mtdc, csp
 #ifndef NDEBUG
 	// XXX: This move is useless, but just for debugging in the simulator.
 	cmove              csp, csp
 #endif
 	// csp now points to the save reg frame that we can use.
-	// The guest csp (c2) is now in mscratchc. Will be spilled later, but we
+	// The guest csp (c2) is now in mtdc. Will be spilled later, but we
 	// spill all other registers now.
 	spillRegisters     c1, cgp, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15
 
@@ -254,8 +256,8 @@ exception_entry_asm:
 	// Store all special resgisters now.
 	cspecialr          ct0, mepcc
 	csc                ct0, TrustedStack_offset_mepcc(csp)
-	// mscratchc got swapped with the thread's csp, store it now.
-	cspecialr          ct1, mscratchc
+	// mtdc got swapped with the thread's csp, store it now
+	cspecialr          ct1, mtdc
 	csc                ct1, TrustedStack_offset_csp(csp)
 	csrr               t1, mstatus
 	csw                t1, TrustedStack_offset_mstatus(csp)
@@ -308,7 +310,7 @@ exception_entry_asm:
 	li                 gp, 10
 	csetaddr           ct0, ct0, gp
 	cunseal            csp, ca0, ct0
-	cspecialw          mscratchc, csp
+	cspecialw          mtdc, csp
 	// Environment call from M-mode is exception code 11.
 	// We need to skip the ecall instruction to avoid an infinite loop.
 	clw                t0, TrustedStack_offset_mcause(csp)
@@ -353,7 +355,7 @@ exception_entry_asm:
 .Lout_of_trusted_stack:
 	cmove              ct0, csp
 	// Fetch the trusted stack pointer.
-	cspecialr          csp, mscratchc
+	cspecialr          csp, mtdc
 	// csp now points to the save reg frame that we can use.
 	// Spill all of the registers that we want to propagate to the caller:
 	// c1(cra), c2(csp), c3(cgp), c8(cs0), c9(cs1), c10(ca0), c11(ca1)
@@ -414,9 +416,9 @@ exception_entry_asm:
 //                                                       size_t             mcause,
 //                                                       size_t             mtval);
 .Lhandle_error:
-	// We're now out of the exception path, so make sure that mscratch contains
+	// We're now out of the exception path, so make sure that mtdc contains
 	// the trusted stack pointer.
-	cspecialw   mscratchc, csp
+	cspecialw   mtdc, csp
 	// Load the interrupted thread's stack pointer into ct0
 	clc                ct0, TrustedStack_offset_csp(csp)
 	// Fetch the base of compartment stack before cincoffset for later
@@ -536,7 +538,7 @@ exception_entry_asm:
 	// detect it as a double fault and forcibly unwind.
 
 	// Load the trusted stack pointer to ct1
-	cspecialr          ct1, mscratchc
+	cspecialr          ct1, mtdc
 	clhu               tp, TrustedStack_offset_frameoffset(ct1)
 	addi               tp, tp, -TrustedStackFrame_size
 	// ctp points to the current available trusted stack frame.
@@ -608,12 +610,12 @@ exception_entry_asm:
 .Lpop_trusted_stack_frame:
 	// The below should not fault before returning back to the caller. If a fault occurs there must
 	// be a serious bug elsewhere.
-	cspecialr          ctp, mscratchc
+	cspecialr          ctp, mtdc
 	// make sure there is a frame left in the trusted stack
 	clhu               t2, TrustedStack_offset_frameoffset(ctp)
 	li                 tp, TrustedStackFrame_size
 	bgeu               tp, t2, .Lset_mcause_and_exit_thread
-	cspecialr          ctp, mscratchc
+	cspecialr          ctp, mtdc
 	addi               t2, t2, -TrustedStackFrame_size
 	cincoffset         ct1, ctp, t2
 	clc                ca2, TrustedStackFrame_offset_pcc(ct1)

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -117,9 +117,8 @@ compartment_switcher_entry:
 	clhu               tp, TrustedStack_offset_frameoffset(ct2)
 	cgetlen            t2, ct2
 	bgeu               tp, t2, .Lout_of_trusted_stack
-	// we are past the stacks checks. Reload ct2 and tp
+	// we are past the stacks checks. Reload ct2; tp is still as it was
 	cspecialr          ct2, mscratchc
-	clhu               tp, TrustedStack_offset_frameoffset(ct2)
 	// ctp points to the current available trusted stack frame.
 	cincoffset         ctp, ct2, tp
 	csc                cra, TrustedStackFrame_offset_pcc(ctp)
@@ -617,7 +616,6 @@ exception_entry_asm:
 	li                 tp, TrustedStackFrame_size
 	bgeu               tp, t2, .Lset_mcause_and_exit_thread
 	cspecialr          ctp, mscratchc
-	clhu               t2, TrustedStack_offset_frameoffset(ctp)
 	addi               t2, t2, -TrustedStackFrame_size
 	cincoffset         ct1, ctp, t2
 	clc                ca2, TrustedStackFrame_offset_pcc(ct1)

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -303,15 +303,10 @@ exception_entry_asm:
 	// ca3, used for mtval
 	zeroAllRegistersExcept ra, sp, gp, a0, a1, a2, a3
 
-	// Call the scheduler.  This returns two values via ca0.  The first is a
-	// sealed trusted stack capability, the second is a return value to be
-	// provided to threads that voluntarily yielded.
+	// Call the scheduler.  This returns the new thread in ca0.
 	cjalr              cra
 
-	// The scheduler returns the new thread in ca0.
-	// We don't need to restore the stack pointer because we're now done with
-	// this stack until the next exception, at which point we'll reload the
-	// original stack pointer.
+	// Switch onto the new thread's trusted stack
 	LoadCapPCC         ct0, compartment_switcher_sealing_key
 	li                 gp, 10
 	csetaddr           ct0, ct0, gp
@@ -327,7 +322,7 @@ exception_entry_asm:
 	// Fall through to install context
 
 // Install context expects csp to point to the trusted stack and ct2 to be the
-// pcc to jump to.  All other registeres are in unspecified states and will be
+// pcc to jump to.  All other registers are in unspecified states and will be
 // overwritten when we install the context.
 .Linstall_context:
 	clw                x1, TrustedStack_offset_mstatus(csp)
@@ -339,7 +334,7 @@ exception_entry_asm:
 	reloadRegisters c1, cgp, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, csp
 	mret
 
-// If we detect an invalud entry and there is no error handler installed, we want
+// If we detect an invalid entry and there is no error handler installed, we want
 // to resume rather than unwind.
 .Linvalid_entry:
 // Mark this threads as in the middle of a forced unwind.

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -245,6 +245,26 @@ exception_entry_asm:
 	// XXX: This move is useless, but just for debugging in the simulator.
 	cmove              csp, csp
 #endif
+
+	// If we read out zero, we've reentered the exception and are about to
+	// trap.  Make sure that we end up in an architectural trap loop: clobber
+	// mtcc, so that trapping attempts to vector to an untagged PCC, thereby
+	// causing another (i.e., a third) trap in spillRegisters, below.
+	//
+	// While that's a good start, it does not guarantee that we end up in a
+	// trap loop: the reentry will probably have put something non-zero into
+	// mtdc, so we wouldn't hit this, and wouldn't loop, when we take that
+	// third trap.  (Exactly what we'd do instead is hard to say; we'd try
+	// spilling registers to an attacker-controlled pointer, at the very
+	// least.) Therefore, clobber mtcc (!) to ensure that the certainly
+	// upcoming third trap puts us in an architectural trap loop.  This is
+	// slightly preferable to clearing mtdc, which would also ensure that we
+	// looped, because the architectural loop is tighter and involves no
+	// program text, making it easier for microarchitecture to detect.
+	bnez               sp, .Lexception_entry_still_alive
+	cspecialw          mtcc, csp
+.Lexception_entry_still_alive:
+
 	// csp now points to the save reg frame that we can use.
 	// The guest csp (c2) is now in mtdc. Will be spilled later, but we
 	// spill all other registers now.
@@ -253,12 +273,17 @@ exception_entry_asm:
 	// If a thread has exited then it will set a fake value in the mcause so
 	// that the scheduler knows not to try to resume it.
 .Lthread_exit:
-	// Store all special resgisters now.
+	// mtdc got swapped with the thread's csp, store it and clobber mtdc with
+	// zero.  The trusted stack pointer is solely in csp, now; if we take
+	// another trap before a new one is installed, or if the scheduler enables
+	// interrupts and we take one, we'll pull this zero out of mtdc, above.
+	zeroOne            t1
+	cspecialrw         ct1, mtdc, ct1
+	csc                ct1, TrustedStack_offset_csp(csp)
+
+	// Store the rest of the special registers
 	cspecialr          ct0, mepcc
 	csc                ct0, TrustedStack_offset_mepcc(csp)
-	// mtdc got swapped with the thread's csp, store it now
-	cspecialr          ct1, mtdc
-	csc                ct1, TrustedStack_offset_csp(csp)
 	csrr               t1, mstatus
 	csw                t1, TrustedStack_offset_mstatus(csp)
 	csrr               t1, mcause
@@ -304,25 +329,39 @@ exception_entry_asm:
 
 	// Call the scheduler.  This returns the new thread in ca0.
 	cjalr              cra
+	// The scheduler may change interrupt posture or may trap, but if it
+	// returns to us (that is, we reach here), the use of the sentry created by
+	// cjalr will have restored us to deferring interrupts, and we will remain
+	// in that posture until the mret in install_context.
 
 	// Switch onto the new thread's trusted stack
 	LoadCapPCC         ct0, compartment_switcher_sealing_key
 	li                 gp, 10
 	csetaddr           ct0, ct0, gp
 	cunseal            csp, ca0, ct0
-	cspecialw          mtdc, csp
 	// Environment call from M-mode is exception code 11.
 	// We need to skip the ecall instruction to avoid an infinite loop.
 	clw                t0, TrustedStack_offset_mcause(csp)
+
+	// Only now that we have done something that actually requires the tag of
+	// csp be set, put it into mtdc.  If the scheduler has returned something
+	// untagged or something with the wrong otype, the cunseal will have left
+	// csp untagged and clw will trap with mtdc still 0.  If we made it here,
+	// though, csp is tagged and so was tagged and correctly typed, and so it
+	// is safe to install it to mtdc.  We won't cause traps between here and
+	// mret, so reentrancy is no longer a concern.
+	cspecialw          mtdc, csp
+
+	// Back to your regularly scheduled program (testing for ecall from M mode)
 	li                 t1, 11
 	clc                ct2, TrustedStack_offset_mepcc(csp)
 	bne                t0, t1, .Linstall_context
 	cincoffset         ct2, ct2, 4
 	// Fall through to install context
 
-// Install context expects csp to point to the trusted stack and ct2 to be the
-// pcc to jump to.  All other registers are in unspecified states and will be
-// overwritten when we install the context.
+// Install context expects csp and mtdc to point to the trusted stack and for
+// ct2 to be the pcc to jump to.  All other registers are in unspecified states
+// and will be overwritten when we install the context.
 .Linstall_context:
 	clw                x1, TrustedStack_offset_mstatus(csp)
 	csrw               mstatus, x1

--- a/sdk/core/switcher/tstack.h
+++ b/sdk/core/switcher/tstack.h
@@ -73,7 +73,7 @@ struct TrustedStackGeneric
 	/**
 	 * The trusted stack.  There is always one frame, describing the entry
 	 * point.  If this is popped then we have run off the stack and the thread
-	 * will exist.
+	 * will exit.
 	 */
 	TrustedStackFrame frames[NFrames + 1];
 };

--- a/sdk/include/cheri.hh
+++ b/sdk/include/cheri.hh
@@ -1235,14 +1235,14 @@ namespace CHERI
 		 *
 		 * Special capability register that contains the memory root capability
 		 * on boot. Only accessible when PCC has the AccessSystemRegisters
-		 * permission. Currently not used after boot in the RTOS.
+		 * permission.  Use by the RTOS to store a capability to the trusted
+		 * stack.
 		 */
 		MTDC = 0x3d,
 		/**
 		 * Machine-mode Scratch Capability. Special capabiltiy register that
 		 * contains the sealing root capability on boot. Only accessible when
-		 * PCC has the AccessSystemRegisters permission. Use by the RTOS to
-		 * store a capability to the trusted stack.
+		 * PCC has the AccessSystemRegisters permission.
 		 */
 		MScratchC = 0x3e,
 		/**


### PR DESCRIPTION
At present, our switcher calls our scheduler while in a "critical section" with `mscratchc` not actually pointing at the trusted save area.  The scheduler is not completely trusted and raising interrupts with `mscratchc` holding an arbitrary user capability seems like a great affordance for some weird machine that breaks everything we hold dear.

The changes here do two things:
- cosmetic changes to use `mtdc` instead of `mscratch` for the trusted save area.  No functional change intended, but it seemed like a good idea while in the neighborhood.
- substantive changes to use `mscratch` as a way of detecting reentrant exceptions.  I don't see a way to do this without two scratch registers, but maybe I'm missing something.

In any case, I took a stab at the problem and... it's not working and it's very late, even for my physical time-zone.  Maybe someone else can tell me what I've gotten wrong.  Comments, criticisms, rotten vegetables?

(This is sitting atop #35 right now; that should merge soon.)