### PR TITLE
Small fixes in timing output.

### DIFF
--- a/benchmarks/allocation/alloc.cc
+++ b/benchmarks/allocation/alloc.cc
@@ -11,8 +11,12 @@ using Debug = ConditionalDebug<DEBUG_ALLOCBENCH, "Allocator benchmark">;
  */
 void __cheri_compartment("allocbench") run()
 {
+	// Make sure sail doesn't print annoying log messages in the middle of the
+	// output the first time that allocation happens.
+	free(malloc(16));
+	heap_quarantine_empty();
 	MessageBuilder<ImplicitUARTOutput> out;
-	out.format("#board\tsize\ttime");
+	out.format("#board\tsize\ttime\n");
 	const size_t MinimumSize = 32;
 	const size_t MaximumSize = 131072;
 	const size_t TotalSize   = 1024 * 1024;

--- a/benchmarks/timing.h
+++ b/benchmarks/timing.h
@@ -8,12 +8,9 @@ namespace
 	{
 		int cycles;
 #ifdef SAIL
-		// The Sail model doesn't implement the unprivileged cycle CSR in
-		// M-mode only configurations, so we use mcycle instead. This requires
-		// that mcycle is accessible read-only without the ASR permission.
-		// Probably Sail should have the cycle CSR even without U-mode but need
-		// clarification on spec.
-		__asm__ volatile("csrr %0, mcycle" : "=r"(cycles));
+		// On Sail, report the number of instructions, the cycle count is
+		// meaningless.
+		__asm__ volatile("csrr %0, minstret" : "=r"(cycles));
 #else
 		__asm__ volatile("rdcycle %0" : "=r"(cycles));
 #endif

--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -16,12 +16,9 @@ namespace
 	{
 		int cycles;
 #ifdef SAIL
-		// The Sail model doesn't implement the unprivileged cycle CSR in
-		// M-mode only configurations, so we use mcycle instead. This requires
-		// that mcycle is accessible read-only without the ASR permission.
-		// Probably Sail should have the cycle CSR even without U-mode but need
-		// clarification on spec.
-		__asm__ volatile("csrr %0, mcycle" : "=r"(cycles));
+		// On Sail, report the number of instructions, the cycle count is
+		// meaningless.
+		__asm__ volatile("csrr %0, minstret" : "=r"(cycles));
 #else
 		__asm__ volatile("rdcycle %0" : "=r"(cycles));
 #endif


### PR DESCRIPTION
On Sail, use minstret instead of mcycle, since it gives a useful number and mcycle does not.