### PR TITLE
Improve C compatibility.

### DIFF
--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -116,7 +116,11 @@
 #define DECLARE_STATIC_SEALED_VALUE(type, compartment, keyName, name)          \
 	struct __##name##_type; /* NOLINT(bugprone-macro-parentheses) */           \
 	extern __if_cxx("C") struct __##name##_type                                \
-	  name; /* NOLINT(bugprone-macro-parentheses) */
+	{                                                                          \
+		uint32_t key;                                                          \
+		uint32_t padding;                                                      \
+		type     body;                                                         \
+	} name /* NOLINT(bugprone-macro-parentheses) */
 
 /**
  * Define a static sealed object.  This creates an object of type `type`,
@@ -134,15 +138,28 @@
 	  "__export.sealing_type." #compartment "." #keyName);                     \
 	__attribute__((section(".sealed_objects"), used))                          \
 	__if_cxx(inline) struct __##name##_type                                    \
-	{                                                                          \
-		uint32_t key;                                                          \
-		uint32_t padding;                                                      \
-		type     body;                                                         \
-	} name = /* NOLINT(bugprone-macro-parentheses) */                          \
+	  name = /* NOLINT(bugprone-macro-parentheses) */                          \
 	  {(uint32_t)&__sealing_key_##compartment##_##keyName,                     \
 	   0,                                                                      \
 	   initialiser,                                                            \
 	   ##__VA_ARGS__}
+
+/**
+ * Helper macro that declares and defines a sealed value.
+ */
+#define DECLARE_AND_DEFINE_STATIC_SEALED_VALUE(                                \
+  type, compartment, keyName, name, initialiser, ...)                          \
+	DECLARE_STATIC_SEALED_VALUE(                                               \
+	  type,                                                                    \
+	  compartment,                                                             \
+	  keyName,                                                                 \
+	  name); /* NOLINT(bugprone-macro-parentheses) */                          \
+	DEFINE_STATIC_SEALED_VALUE(                                                \
+	  type,                                                                    \
+	  compartment,                                                             \
+	  keyName,                                                                 \
+	  name,                                                                    \
+	  initialiser); /* NOLINT(bugprone-macro-parentheses) */
 
 /**
  * Returns a sealed capability to the named object created with

--- a/sdk/include/multiwaiter.h
+++ b/sdk/include/multiwaiter.h
@@ -30,6 +30,7 @@
  * expected number of waited objects is small and so is the number of threads.
  */
 #include <compartment.h>
+#include <stdlib.h>
 #include <timeout.h>
 
 /**

--- a/sdk/include/stdlib.h
+++ b/sdk/include/stdlib.h
@@ -54,6 +54,14 @@ struct SObjStruct;
 	                           0,                                              \
 	                           {0, 0});
 
+/**
+ * Helper macro to define an allocator capability without a separate
+ * declaration.
+ */
+#define DECLARE_AND_DEFINE_ALLOCATOR_CAPABILITY(name, quota)                   \
+	DECLARE_ALLOCATOR_CAPABILITY(name);                                        \
+	DEFINE_ALLOCATOR_CAPABILITY(name, quota)
+
 #ifndef CHERIOT_NO_AMBIENT_MALLOC
 /**
  * Declare a default capability for use with malloc-style APIs.  Compartments
@@ -61,11 +69,11 @@ struct SObjStruct;
  * heaps) can define `CHERIOT_NO_AMBIENT_MALLOC` to disable this.
  */
 DECLARE_ALLOCATOR_CAPABILITY(__default_malloc_capability)
-#	ifndef CUSTOM_DEFAULT_MALLOC_CAPARBILITY
+#	ifndef CHERIOT_CUSTOM_DEFAULT_MALLOC_CAPABILITY
 /**
  * Define the capability for use with malloc-style APIs. In C code, this may be
  * defined in precisely on compilation unit per compartment.  Others should
- * define `CUSTOM_DEFAULT_MALLOC_CAPARBILITY` to avoid the definition.
+ * define `CHERIOT_CUSTOM_DEFAULT_MALLOC_CAPABILITY` to avoid the definition.
  */
 DEFINE_ALLOCATOR_CAPABILITY(__default_malloc_capability, MALLOC_QUOTA)
 #	endif

--- a/sdk/include/token.h
+++ b/sdk/include/token.h
@@ -36,7 +36,7 @@ __BEGIN_DECLS
  * If the sealing keys have been exhausted then this will return
  * `INVALID_SKEY`.  This API is guaranteed never to block.
  */
-SKey __cheri_compartment("alloc") token_key_new();
+SKey __cheri_compartment("alloc") token_key_new(void);
 
 /**
  * Allocate a new object with size `sz`.

--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -15,7 +15,7 @@
 #include <vector>
 
 using thread_pool::async;
-DEFINE_ALLOCATOR_CAPABILITY(secondHeap, 1024);
+DECLARE_AND_DEFINE_ALLOCATOR_CAPABILITY(secondHeap, 1024);
 
 namespace
 {

--- a/tests/static_sealing-test.cc
+++ b/tests/static_sealing-test.cc
@@ -9,11 +9,11 @@
 using namespace CHERI;
 
 // Create a static sealed object that we can't access
-DEFINE_STATIC_SEALED_VALUE(TestType,
-                           static_sealing_inner,
-                           SealingType,
-                           test,
-                           {42});
+DECLARE_AND_DEFINE_STATIC_SEALED_VALUE(TestType,
+                                       static_sealing_inner,
+                                       SealingType,
+                                       test,
+                                       {42});
 
 void test_static_sealing()
 {


### PR DESCRIPTION
Updating the demo found a few places where C compatibility was not quite right.  In particular, C doesn't merge compatible definitions, which causes a lot of pain with the static sealing type macros.