### PR TITLE
Add (optional) scheduler APIs for reporting the time.

### DIFF
--- a/sdk/core/scheduler/common.h
+++ b/sdk/core/scheduler/common.h
@@ -24,6 +24,15 @@ namespace sched
 #endif
 	  ;
 
+	/// Is scheduler accounting enabled?
+	constexpr bool Accounting =
+#ifdef SCHEDULER_ACCOUNTING
+	  SCHEDULER_ACCOUNTING
+#else
+	  false
+#endif
+	  ;
+
 	using Debug = ConditionalDebug<DebugScheduler, "Scheduler">;
 	/**
 	 * Base class for types that are exported from the scheduler with a common

--- a/sdk/core/scheduler/thread.h
+++ b/sdk/core/scheduler/thread.h
@@ -491,6 +491,13 @@ namespace sched
 		/// If suspended, when will this thread expire. The maximum value is
 		/// special-cased to mean blocked indefinitely.
 		uint64_t expiryTime;
+
+		/// The number of cycles that this thread has been scheduled for.
+		uint64_t cycles;
+
+		/// The number of cycles accounted to the idle thread.
+		static inline uint64_t idleThreadCycles;
+
 		union
 		{
 			/// When the thread wakes up from event group, this stores the bits

--- a/sdk/include/debug.hh
+++ b/sdk/include/debug.hh
@@ -164,12 +164,10 @@ namespace
 		}
 
 		/**
-		 * Append a size to the buffer.
+		 * Append a 32-bit unsigned integer to the buffer as hex with no prefix.
 		 */
-		__attribute__((noinline)) void append(uint32_t s)
+		__attribute__((noinline)) void append_hex_word(uint32_t s)
 		{
-			append_char('0');
-			append_char('x');
 			std::array<char, 8> buf;
 			const char          Hexdigits[] = "0123456789abcdef";
 			// Length of string including null terminator
@@ -193,6 +191,32 @@ namespace
 			{
 				append_char('0');
 			}
+		}
+
+		/**
+		 * Append a 32-bit unsigned integer to the buffer as hex.
+		 */
+		__attribute__((noinline)) void append(uint32_t s)
+		{
+			append_char('0');
+			append_char('x');
+			append_hex_word(s);
+		}
+
+		/**
+		 * Append a 64-bit unsigned integer to the buffer as hex.
+		 */
+		__attribute__((noinline)) void append(uint64_t s)
+		{
+			append_char('0');
+			append_char('x');
+			uint32_t hi = static_cast<uint32_t>(s >> 32);
+			uint32_t lo = static_cast<uint32_t>(s);
+			if (hi != 0)
+			{
+				append_hex_word(hi);
+			}
+			append_hex_word(lo);
 		}
 
 		/**

--- a/sdk/include/riscvreg.h
+++ b/sdk/include/riscvreg.h
@@ -18,7 +18,7 @@
 #define CSR_READ64(csr)                                                        \
 	({                                                                         \
 		uint64_t val;                                                          \
-		size_t   high, low;                                                    \
+		uint32_t high, low;                                                    \
 		__asm __volatile("1: "                                                 \
 		                 "csrr t0, " #csr "h\n"                                \
 		                 "csrr %0, " #csr "\n"                                 \
@@ -42,3 +42,12 @@
 	})
 
 #define BARRIER() __asm volatile("" : : : "memory")
+
+/**
+ * Read the cycle counter.  Returns the number of cycles since boot as a 64-bit
+ * value.
+ */
+static inline uint64_t rdcycle64()
+{
+	return CSR_READ64(mcycle);
+}

--- a/sdk/include/thread.h
+++ b/sdk/include/thread.h
@@ -43,4 +43,21 @@ typedef struct
  */
 [[cheri::interrupt_state(disabled)]] uint16_t __cheri_compartment("sched")
   thread_id_get(void);
+
+/**
+ * Returns the number of cycles accounted to the idle thread.
+ *
+ * This API is available only if the scheduler is built with accounting support
+ * enabled.
+ */
+__cheri_compartment("sched") uint64_t thread_elapsed_cycles_idle(void);
+
+/**
+ * Returns the number of cycles accounted to the current thread.
+ *
+ * This API is available only if the scheduler is built with accounting
+ * support enabled.
+ */
+__cheri_compartment("sched") uint64_t thread_elapsed_cycles_current(void);
+
 __END_DECLS

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -11,6 +11,11 @@ if is_mode("release") then
     add_defines("NDEBUG", {force = true})
 end
 
+option("scheduler-accounting")
+	set_default(false)
+	set_description("Track per-thread cycle counts in the scheduler");
+	set_showmenu(true)
+
 function debugOption(name)
 	option("debug-" .. name)
 		set_default(false)
@@ -498,6 +503,7 @@ function firmware(name)
 		on_load(function (target)
 			target:set("cherimcu.compartment", "sched")
 			target:set('cherimcu.debug-name', "scheduler")
+			target:add('defines', "SCHEDULER_ACCOUNTING=" .. tostring(get_config("scheduler-accounting")))
 		end)
 		add_files(path.join(coredir, "scheduler/main.cc"))
 


### PR DESCRIPTION
These are guarded behind a flag enabled in the build system and the scheduler doesn't track them if they are not enabled.

Since it's unhelpful to be able to get 64-bit numbers and not log them for debugging, the `ConditionalDebug::log` mechanism can now log unsigned 64-bit values as hex.  Logging them as decimal requires a 64-bit divide, so that's not done yet (as hex the two 32-bit halves can simply be printed separately, high then low).