### PR TITLE
Ensure the trusted stack stack size is a multiple of 16-bytes.

### DIFF
--- a/sdk/core/loader/defines.h
+++ b/sdk/core/loader/defines.h
@@ -14,6 +14,6 @@
  * the idle thread must not do compartment calls, this trusted stack only needs
  * to have a register frame and not trusted stack frames.
  */
-#define BOOT_TSTACK_SIZE (TSTACK_REGFRAME_SZ + TSTACK_HEADER_SZ + (7 * 8))
+#define BOOT_TSTACK_SIZE (TSTACK_REGFRAME_SZ + TSTACK_HEADER_SZ + (8 * 8))
 
 #define BOOT_THREADINFO_SZ 16

--- a/sdk/core/switcher/trusted-stack-assembly.h
+++ b/sdk/core/switcher/trusted-stack-assembly.h
@@ -21,15 +21,16 @@ EXPORT_ASSEMBLY_OFFSET(TrustedStack, c14, 14 * 8)
 EXPORT_ASSEMBLY_OFFSET(TrustedStack, c15, 15 * 8)
 EXPORT_ASSEMBLY_OFFSET(TrustedStack, mstatus, 16 * 8)
 EXPORT_ASSEMBLY_OFFSET(TrustedStack, mcause, (16 * 8) + 4)
-
+// Size of everything up to this point
 #define TSTACK_REGFRAME_SZ ((16 * 8) + (2 * 4))
+// frameoffset, inForcedUnwind and padding
 #define TSTACK_HEADER_SZ 8
 // The basic trusted stack is the size of the save area, 8 bytes of state for
 // unwinding information, and then a single trusted stack frame used for the
 // unwind state of the initial thread. (7 * 8) is the size of TrustedStackFrame
 // and will match the value below.
-EXPORT_ASSEMBLY_SIZE(TrustedStack, TSTACK_REGFRAME_SZ + 8 + (7 * 8))
-EXPORT_ASSEMBLY_OFFSET(TrustedStack, frames, TSTACK_REGFRAME_SZ + 8)
+EXPORT_ASSEMBLY_SIZE(TrustedStack, TSTACK_REGFRAME_SZ + TSTACK_HEADER_SZ + (8 * 8))
+EXPORT_ASSEMBLY_OFFSET(TrustedStack, frames, TSTACK_REGFRAME_SZ + TSTACK_HEADER_SZ)
 EXPORT_ASSEMBLY_OFFSET(TrustedStack, frameoffset, TSTACK_REGFRAME_SZ)
 EXPORT_ASSEMBLY_OFFSET(TrustedStack, inForcedUnwind, TSTACK_REGFRAME_SZ + 2)
 
@@ -40,7 +41,7 @@ EXPORT_ASSEMBLY_OFFSET(TrustedStackFrame, cs0, 24)
 EXPORT_ASSEMBLY_OFFSET(TrustedStackFrame, cs1, 32)
 EXPORT_ASSEMBLY_OFFSET(TrustedStackFrame, calleeExportTable, 40)
 EXPORT_ASSEMBLY_OFFSET(TrustedStackFrame, errorHandlerCount, 48)
-EXPORT_ASSEMBLY_SIZE(TrustedStackFrame, (7 * 8))
+EXPORT_ASSEMBLY_SIZE(TrustedStackFrame, (8 * 8))
 
 #define TSTACKOFFSET_FIRSTFRAME                                                \
 	(TrustedStack_offset_frameoffset + TSTACK_HEADER_SZ)
@@ -49,6 +50,6 @@ EXPORT_ASSEMBLY_SIZE(TrustedStackFrame, (7 * 8))
  *  We use this in the switcher, to verify the CSP comes from the
  *  compartment is exactly what we expect.
  *  This represents the following permissions:
- *  Load, Store, LoadStnoreCapability, LoadMutable StoreLocal and LoadGlobal
+ *  Load, Store, LoadStoreCapability, LoadMutable StoreLocal and LoadGlobal
  */
 #define COMPARTMENT_STACK_PERMISSIONS 0x7e

--- a/sdk/core/switcher/tstack.h
+++ b/sdk/core/switcher/tstack.h
@@ -37,8 +37,8 @@ struct TrustedStackFrame
 	 * will forcibly unwind the stack.
 	 */
 	uint16_t errorHandlerCount;
-	/// reserved fields for extra caller information
-	uint16_t res[3];
+	// padding to make up to multiple of 16 bytes
+	uint16_t padding[7];
 };
 
 template<size_t NFrames>
@@ -67,7 +67,8 @@ struct TrustedStackGeneric
 	 * Flag indicating whether this thread is in the process of a forced
 	 * unwind.  If so, this is one, otherwise it is zero.
 	 */
-	uint8_t  inForcedUnwind;
+	uint8_t inForcedUnwind;
+	// Padding up to multiple of 16-bytes.
 	uint8_t  pad0;
 	uint16_t padding[2];
 	/**
@@ -80,6 +81,16 @@ struct TrustedStackGeneric
 using TrustedStack = TrustedStackGeneric<0>;
 
 #include "trusted-stack-assembly.h"
+
+// Require the trusted stack to be a multiple of 16 bytes. We could get away
+// without this except that the loader rounds the stack size up to a multiple of
+// 16 bytes and it confuses the overflow check in the switcher if the allocated
+// stack length does not match the expected length.
+static_assert((sizeof(TrustedStack) % 16) == 0);
+// We don't want the above to depend on the number of trusted stack frames
+// allocated so we'd better make sure TrustedStackFrame is also a multiple of 16
+// bytes.
+static_assert((sizeof(TrustedStackFrame) % 16) == 0);
 
 static_assert(
   CheckSize<COMPARTMENT_STACK_PERMISSIONS,


### PR DESCRIPTION
Prior to this a TrustedStackFrame was 56 bytes.
This was a problem because it meant that the size of the trusted stack was not always a multiple of 16 bytes (depending on whether there were an odd or even number of frames). If the trusted stack size is not a multiple of 16-bytes the loader would round it up which confused the overflow check in the switcher and could lead to an unexpected trap which would leak capabilities.

This change adds an extra 8 bytes of padding to TrustedStackSize to ensure it is a multiple of 16-bytes.
We also add two static asserts to check this.