### PR TITLE
Fix the no-temporal-safety mode.

### DIFF
--- a/sdk/core/allocator/revoker.h
+++ b/sdk/core/allocator/revoker.h
@@ -314,6 +314,13 @@ namespace Revocation
 		{
 			return true;
 		}
+		bool shadow_bit_get(size_t addr)
+		{
+			Debug::Assert(false,
+			              "shadow_bit_get should not be called on the revoker "
+			              "with no temporal safety, its result is meaningless");
+			return false;
+		}
 	};
 
 	/**


### PR DESCRIPTION
This should never be used in production but helps provide a baseline for the cost of various hardware features.