### PR TITLE
Fix asserts to not run in releases.

### DIFF
--- a/sdk/include/debug.hh
+++ b/sdk/include/debug.hh
@@ -668,6 +668,13 @@ namespace
 		 */
 		template<typename... Ts>
 		Assert(bool, const char *, Ts &&...) -> Assert<Ts...>;
+
+		/**
+		 * Deduction guide, allows `Assert` to be used as if it were a
+		 * function with a lambda argument.
+		 */
+		template<typename... Ts>
+		Assert(auto, const char *, Ts &&...) -> Assert<Ts...>;
 	};
 
 } // namespace


### PR DESCRIPTION
Some of the asserts depended on `volatile` loads and stores and so were still (partially) compiled in.  The cost of these for 32-byte allocations was roughly equal to the cost of shadow bit manipulation, so had a significant impact on the benchmarks.