### PR TITLE
Add a fast accessor for the thread ID.

### DIFF
--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -662,6 +662,11 @@ int multiwaiter_wait(Timeout           *timeout,
 	});
 }
 
+uint16_t *thread_id_get_pointer(void)
+{
+	return sched::Thread::current_thread_id_pointer();
+}
+
 #ifdef SCHEDULER_ACCOUNTING
 [[cheri::interrupt_state(disabled)]] uint64_t thread_elapsed_cycles_idle()
 {

--- a/sdk/core/scheduler/thread.h
+++ b/sdk/core/scheduler/thread.h
@@ -103,7 +103,13 @@ namespace sched
 			}
 
 			current = priorityList[highestPriority];
-			return current ? current->tStackPtr : schedTStack;
+			if (current)
+			{
+				currentThreadId = current->threadId;
+				return current->tStackPtr;
+			}
+			currentThreadId = 0;
+			return schedTStack;
 		}
 
 		/**
@@ -516,9 +522,23 @@ namespace sched
 		};
 		TrustedStack *tStackPtr;
 
+		/**
+		 * Returns a read-only pointer to a variable containing the current
+		 * thread ID.
+		 */
+		static uint16_t *current_thread_id_pointer()
+		{
+			CHERI::Capability ptr{&currentThreadId};
+			ptr.permissions() &= CHERI::PermissionSet{CHERI::Permission::Global,
+			                                          CHERI::Permission::Load};
+			return ptr;
+		}
+
 		private:
 		/// the current runnning thread
 		static inline ThreadImpl *current;
+		/// The ID of the current thread.
+		static inline uint16_t currentThreadId;
 		/// NPrios number of lists, each linking the threads of this priority
 		static inline ThreadImpl *priorityList[NPrios];
 		/// A bit field indicating the presence of ready threads. A set bit at

--- a/sdk/include/thread.h
+++ b/sdk/include/thread.h
@@ -45,6 +45,13 @@ typedef struct
   thread_id_get(void);
 
 /**
+ * Returns a cacheable (read-only) pointer to a global owned by the scheduler
+ * that contains the current thread ID.  Reading this pointer will return the
+ * thread ID of the currently running thread.
+ */
+__cheri_compartment("sched") uint16_t *thread_id_get_pointer(void);
+
+/**
  * Returns the number of cycles accounted to the idle thread.
  *
  * This API is available only if the scheduler is built with accounting support
@@ -61,3 +68,15 @@ __cheri_compartment("sched") uint64_t thread_elapsed_cycles_idle(void);
 __cheri_compartment("sched") uint64_t thread_elapsed_cycles_current(void);
 
 __END_DECLS
+#ifdef __cplusplus
+/**
+ * Helper function that returns the current thread ID.  This will do a
+ * cross-compartment call the first time it is called but not on any subsequent
+ * calls.
+ */
+inline uint16_t thread_id_get_fast()
+{
+	static auto *ptr = thread_id_get_pointer();
+	return *ptr;
+}
+#endif

--- a/tests/thread_pool-test.cc
+++ b/tests/thread_pool-test.cc
@@ -17,6 +17,12 @@ void test_thread_pool()
 	// We can't share stack variables, so create a heap allocation that we can
 	// capture as an explicit pointer.
 	int *heapInt = new (malloc(sizeof(int))) int(0);
+	TEST(thread_id_get() == 1,
+	     "Thread id of main thread should be 1, is {}",
+	     thread_id_get());
+	TEST(thread_id_get_fast() == 1,
+	     "Thread id of main thread should be 1, is {}",
+	     thread_id_get_fast());
 	// Run a simple stateless callback that increments a global in the thread
 	// pool.  This demonstrates that we can correctly capture a stateless
 	// function and pass it to the worker thread.
@@ -49,4 +55,14 @@ void test_thread_pool()
 	TEST(*heapInt == 1, "Heap-allocated integer is {}, should be 1", *heapInt);
 	debug_log("Freeing heap int: {}", heapInt);
 	free(heapInt);
+
+	async([]() {
+		auto fast = thread_id_get_fast();
+		auto slow = thread_id_get();
+		TEST(fast == slow,
+		     "Thread ID is different in fast ({}) and slow ({}) accessors",
+		     fast,
+		     slow);
+		TEST(fast != 1, "Thread ID for thread pool thread should not be 1");
+	});
 }


### PR DESCRIPTION
This might be useful for TLS abstractions and will be necessary for priority-inheriting futexes.