### PR TITLE
Add support for priority inheritance.

### DIFF
--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -51,7 +51,7 @@ namespace
 	 * allocation fails for transient reasons then the lock will be dropped and
 	 * reacquired over the yield.
 	 */
-	FlagLock lock;
+	FlagLockPriorityInherited lock;
 
 	/**
 	 * @brief Take a memory region and initialise a memory space for it. The
@@ -115,7 +115,7 @@ namespace
 	 * Futex value to allow a thread to wait for another thread to free an
 	 * object.
 	 */
-	uint32_t freeFutex;
+	cheriot::atomic<int32_t> freeFutex = -1;
 
 	/**
 	 * Helper that returns true if the timeout value permits sleeping.
@@ -249,15 +249,17 @@ namespace
 				Debug::log("Not enough free space to handle {}-byte "
 				           "allocation, sleeping",
 				           bytes);
+				// Use the current free space as the sleep futex value.  This
+				// means that the `wait` call will fail if the amount of free
+				// memory changes between dropping the lock and waiting, unless
+				// a matched number of allocations and frees happen (in which
+				// case, we're happy to sleep because we still can't manage
+				// this allocation).
+				auto expected = gm->heapFreeSize;
+				freeFutex     = expected;
 				// Drop the lock while yielding
 				g.unlock();
-				auto err = futex_timed_wait(timeout, &freeFutex, ++freeFutex);
-				Debug::Assert(
-				  err != -EINVAL,
-				  "Invalid arguments to futex_timed_wait({}, {}, {})",
-				  &freeFutex,
-				  freeFutex,
-				  timeout);
+				auto err = freeFutex.wait(timeout, expected);
 				// If we timed out, we don't need to reacquire the lock, just
 				// exit
 				if (err == -ETIMEDOUT)
@@ -821,11 +823,11 @@ int heap_free(SObj heapCapability, void *rawPointer)
 	}
 
 	// If there are any threads blocked allocating memory, wake them up.
-	if (freeFutex > 0)
+	if (freeFutex != -1)
 	{
 		Debug::log("Some threads are blocking on allocations, waking them");
-		freeFutex = 0;
-		futex_wake(&freeFutex, -1);
+		freeFutex = -1;
+		freeFutex.notify_all();
 	}
 
 	return 0;
@@ -863,7 +865,7 @@ ssize_t heap_free_all(SObj heapCapability)
 	{
 		Debug::log("Some threads are blocking on allocations, waking them");
 		freeFutex = 0;
-		futex_wake(&freeFutex, -1);
+		freeFutex.notify_all();
 	}
 
 	return freed;

--- a/sdk/include/thread.h
+++ b/sdk/include/thread.h
@@ -76,7 +76,11 @@ __END_DECLS
  */
 inline uint16_t thread_id_get_fast()
 {
-	static auto *ptr = thread_id_get_pointer();
+	static uint16_t *ptr;
+	if (!ptr)
+	{
+		ptr = thread_id_get_pointer();
+	}
 	return *ptr;
 }
 #endif

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -91,7 +91,7 @@ firmware("test-suite")
         target:values_set("threads", {
             {
                 compartment = "test_runner",
-                priority = 2,
+                priority = 3,
                 entry_point = "run_tests",
                 stack_size = 0x600,
                 -- This must be an odd number for the trusted stack exhaustion
@@ -100,7 +100,7 @@ firmware("test-suite")
             },
             {
                 compartment = "thread_pool",
-                priority = 1,
+                priority = 2,
                 entry_point = "thread_pool_run",
                 stack_size = 0x600,
                 trusted_stack_frames = 8


### PR DESCRIPTION
Each thread now has its static priority and the priority that it is boosted to.  The futex wait operation now takes some flags, one of which is for priority inheriting futexes.  If this is used then the futex word is expected to contain the thread ID of the lock owner in the low 16 bits (similar to the Linux PI futex model).  That thread will then inherit the priority of the caller of futex wait, for the duration of the wait (when the wait returns, the priority of the interrupted thread is restored).

This also adds a number of tests, introduces a priority inheriting flag lock, and makes the allocator use it.

This fixes the issue that a low-priority thread that is preempted in the allocator can prevent higher-priority threads from being able to make progress.