### PR TITLE
Start providing some sensible driver interfaces.

### DIFF
--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -33,4 +33,5 @@ riscv32-unknown-unknown
 -DCONFIG_THREADS={{1,2,1024,5},{2,1,1024,5},{3,1,1024,5},}
 -DCONFIG_THREADS_ENTRYPOINTS={LA_ABS(__export_test_runner__Z9run_testsv),LA_ABS(__export_thread_pool__Z15thread_pool_runv),LA_ABS(__export_thread_pool__Z15thread_pool_runv),}
 -DCONFIG_THREADS_NUM=3
+-DREVOKABLE_MEMORY_START=0x80000000
 -DCLANG_TIDY

--- a/sdk/boards/flute-debug-uart.json
+++ b/sdk/boards/flute-debug-uart.json
@@ -34,6 +34,10 @@
 		"end"   : 0x80040000
 	},
 	"revoker" : "hardware",
+	"driver_includes" : [
+		"../include/platform/flute",
+		"../include/platform/generic-riscv"
+	],
 	"defines" : "FLUTE",
 	"timer_hz" : 40000,
 	"tickrate_hz" : 10,

--- a/sdk/boards/flute-software-revoker.json
+++ b/sdk/boards/flute-software-revoker.json
@@ -25,6 +25,10 @@
 	"heap" : {
 		"end"   : 0x80040000
 	},
+	"driver_includes" : [
+		"../include/platform/flute",
+		"../include/platform/generic-riscv"
+	],
 	"defines" : "FLUTE",
 	"timer_hz" : 40000,
 	"tickrate_hz" : 10,

--- a/sdk/boards/flute.json
+++ b/sdk/boards/flute.json
@@ -33,6 +33,10 @@
 	"heap" : {
 		"end"   : 0x80040000
 	},
+	"driver_includes" : [
+		"../include/platform/flute",
+		"../include/platform/generic-riscv"
+	],
 	"defines" : "FLUTE",
 	"timer_hz" : 40000,
 	"tickrate_hz" : 10,


### PR DESCRIPTION
Board descriptions can now provide a set of paths for SoC-specific includes.  These are ordered, so `#include_next` can work to provide customisations if necessary.

This is now used for the Flute hardware revoker (which is a prototype) and should make it easy to support the recently added Ibex revoker.

The same interface should be used for interrupt controllers, which are currently somewhat tangled with the scheduler but that's follow-on work.