### PR TITLE
Use imprecise setbounds for the software revoker's regions.

### DIFF
--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -1226,7 +1226,7 @@ extern "C" SchedulerEntryInfo loader_entry_point(const ImgHdr &imgHdr,
 	auto scaryCapabilities = build<Capability<void>,
 	                               Root::Type::RWStoreL,
 	                               Root::Permissions<Root::Type::RWStoreL>,
-	                               false>(
+	                               /* Precise: */ false>(
 	  imgHdr.privilegedCompartments.software_revoker().code.start(),
 	  3 * sizeof(void *));
 	// Read-write capability to all globals.  This is scary because a bug in

--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -1219,7 +1219,7 @@ extern "C" SchedulerEntryInfo loader_entry_point(const ImgHdr &imgHdr,
 	// that the regions are completely scanned and scanning slightly more is
 	// not a problem unless the revoker is compromised.  The software revoker
 	// already has a terrifying set of rights, so this doesn't really make
-	// things worse and is a nother good reason to use a hardware revoker.
+	// things worse and is another good reason to use a hardware revoker.
 	// Given that hardware revokers are lower power, faster, and more secure,
 	// there's little reason for the software revoker to be used for anything
 	// other than testing.


### PR DESCRIPTION
This ensures that we have a valid tagged capability that spans the regions that must be scanned.  We may also scan some regions that cannot contain revocable capabilities.

Fixes #76