### PR TITLE
Round the heap region in the loader.

### DIFF
--- a/sdk/firmware.ldscript.in
+++ b/sdk/firmware.ldscript.in
@@ -114,7 +114,6 @@ SECTIONS
 
 	# Everything after this point can be discarded after the loader has
 	# finished.
-	. = ALIGN(512);
 	__export_mem_heap = @heap_start@;
 
 	__cap_relocs :


### PR DESCRIPTION
We were always aligning the heap to a 512-byte boundary.  This works on 256 KiB platforms (though is too aggressive if > 50% of the memory is used for code and globals) and works 50% of the time on 512-byte platforms.  Do the rounding in the loader so that it can be based on the total size.

Fixes #75