### PR TITLE
Add a ring buffer and move the thread pool to using it.

### DIFF
--- a/sdk/core/scheduler/thread.h
+++ b/sdk/core/scheduler/thread.h
@@ -249,7 +249,7 @@ namespace sched
 		template<typename Visitor,
 		         typename TerminateCondition = decltype([]() { return false; })>
 		__always_inline void static walk_thread_list(
-		  ThreadImpl          *list,
+		  ThreadImpl         *&list,
 		  Visitor            &&visitor,
 		  TerminateCondition &&terminateCondition = TerminateCondition{})
 		{
@@ -259,9 +259,12 @@ namespace sched
 				// Get the next pointer *before* any operation that might
 				// remove this thread from the list.
 				auto *next = thread->next;
+				// The thread queues are actually circularly linked lists to
+				// avoid a head and tail pointer for each queue, so we spot the
+				// last thread if it's the end.
+				next = (list == next) ? nullptr : next;
 				visitor(thread);
-				// The last thread left in the list points to itself.
-				thread = (thread == next) ? nullptr : thread = next;
+				thread = next;
 			}
 		}
 

--- a/sdk/include/locks.hh
+++ b/sdk/include/locks.hh
@@ -197,12 +197,47 @@ class TicketLock
 	 */
 	void unlock()
 	{
-		uint32_t currentSnapshot = current++;
+		uint32_t currentSnapshot = ++current;
 		if (next > currentSnapshot)
 		{
 			futex_wake(futex_word(), std::numeric_limits<uint32_t>::max());
 		}
 	}
+};
+
+/**
+ * Class that implements the locking concept but does not perform locking.
+ * This is intended to be used with templated data structures that support
+ * locking, for instantiations that do not require locking.
+ */
+class NoLock
+{
+	public:
+	/**
+	 * Attempt to acquire the lock with a timeout.  Always succeeds.
+	 */
+	bool try_lock(Timeout *timeout)
+	{
+		return true;
+	}
+
+	/**
+	 * Try to acquire the lock, do not block.  Always succeeds.
+	 */
+	bool try_lock()
+	{
+		return true;
+	}
+
+	/**
+	 * Acquire the lock.  Always succeeds
+	 */
+	void lock() {}
+
+	/**
+	 * Release the lock.  Does nothing.
+	 */
+	void unlock() {}
 };
 
 template<typename T>
@@ -220,6 +255,7 @@ concept TryLockable = Lockable<T> && requires(T l, Timeout *t)
 		} -> std::same_as<bool>;
 };
 
+static_assert(TryLockable<NoLock>);
 static_assert(TryLockable<FlagLock>);
 static_assert(Lockable<TicketLock>);
 

--- a/sdk/include/ring_buffer.hh
+++ b/sdk/include/ring_buffer.hh
@@ -1,0 +1,131 @@
+
+#pragma once
+#include <limits>
+#include <locks.hh>
+#include <thread.h>
+#include <utils.hh>
+
+/**
+ * A simple single-producer, single-consumer ring buffer that can be made
+ * multi-producer and / or multi-consumer by adding locking.  The first two
+ * template parameters are the type of the message and the size of the buffer
+ * (in messages).  The next template arguments are the locks to use for
+ * protecting the producer and consumer ends.
+ *
+ * In the uncontended (or single-producer, single-consumer) case where the
+ * producer and consumer are balanced and the ring is neither full nor empty,
+ * this will not use any cross-compartment calls.  When the queue is full,
+ * producers will block on a futex.  When the queue is empty, consumers will
+ * block on a futex.  On transitions to non-empty and non-full, the queue will
+ * issue a `futex_wake` cross-compartment call. If locks are used, they may
+ * introduce additional cross-compartment calls.
+ *
+ * Note: The size must be a power of two.
+ */
+template<typename Message,
+         size_t BufferSize,
+         typename PushLock = NoLock,
+         typename PopLock  = NoLock>
+class RingBuffer
+{
+	/// The ring buffer.
+	std::array<Message, BufferSize> ring;
+	/// The lock protecting the push end, if one exists.
+	[[no_unique_address]] PushLock pushLock;
+	/// The lock protecting the pop end, if one exists.
+	[[no_unique_address]] PopLock popLock;
+	/// Free-running producer counter.
+	_Atomic(uint32_t) producer;
+	/// Free-running consumer counter.
+	_Atomic(uint32_t) consumer;
+
+	static_assert(BufferSize < std::numeric_limits<uint32_t>::max() / 2,
+	              "The buffer size cannot be more than half the range of the "
+	              "counter types or overflow will give incorrect values");
+	static_assert((1 << utils::log2<BufferSize>()) == BufferSize,
+	              "Buffer size must be a power of two");
+
+	/**
+	 * Helper to check if the ring is full.  The counters are free running and
+	 * so the displacement between them (wrapping for overflow) will be the
+	 * number of elements in the buffer if the ring is full.
+	 */
+	bool is_full()
+	{
+		return producer - consumer == BufferSize;
+	}
+
+	/**
+	 * Check if the queue is empty.  If the consumer counter has caught up with
+	 * the producer then this ring is empty.
+	 */
+	bool is_empty()
+	{
+		return producer == consumer;
+	}
+
+	/**
+	 * Helper to convert the counter value to an array index.  The counters are
+	 * never reset and so this is simple modulo arithmetic.  Power of two sizes
+	 * are more efficient because they become bit masks.
+	 */
+	size_t counter_to_index(size_t counter)
+	{
+		return counter % BufferSize;
+	}
+
+	public:
+	/**
+	 * Push an element into the ring.  The caller is responsible for ensuring
+	 * that, if this contains pointers, they have the global permission and so
+	 * the move operation will not fault.
+	 */
+	void push(Message &&message)
+	{
+		LockGuard g{pushLock};
+		// Wait for the queue to not be full
+		while (is_full())
+		{
+			futex_wait(reinterpret_cast<uint32_t *>(&consumer),
+			           producer - BufferSize);
+		}
+		auto i        = counter_to_index(producer);
+		ring[i]       = std::move(message);
+		bool wasEmpty = is_empty();
+		producer++;
+		g.unlock();
+		if (wasEmpty)
+		{
+			futex_wake(reinterpret_cast<uint32_t *>(&producer),
+			           std::numeric_limits<uint32_t>::max());
+		}
+	}
+
+	/**
+	 * Pop the next message from the queue.
+	 */
+	Message pop()
+	{
+		Message   result;
+		LockGuard g{popLock};
+		// Wait for the queue to not be full
+		while (is_empty())
+		{
+			futex_wait(reinterpret_cast<uint32_t *>(&producer), consumer);
+		}
+		auto i       = counter_to_index(consumer);
+		result       = std::move(ring[i]);
+		bool wasFull = is_full();
+		consumer++;
+		g.unlock();
+		if (wasFull)
+		{
+			futex_wake(reinterpret_cast<uint32_t *>(&consumer),
+			           std::numeric_limits<uint32_t>::max());
+		}
+		return result;
+	}
+};
+
+// Make sure that locks consume no space if not used.
+static_assert(sizeof(RingBuffer<uint32_t, 2>) == 16);

--- a/sdk/lib/thread_pool/thread_pool.cc
+++ b/sdk/lib/thread_pool/thread_pool.cc
@@ -3,27 +3,22 @@
 
 #include <errno.h>
 #include <queue.h>
+#include <ring_buffer.hh>
+#include <thread.h>
 #include <thread_pool.h>
 
 using namespace CHERI;
 
 namespace
 {
+
 	/**
-	 * Helper to lazily initialise a queue.
+	 * Ring buffer.  We use a ticket lock to ensure that things are dispatched
+	 * in order (independent of priority) on the sending side and a flag lock on
+	 * the other side to ensure that the highest-priority thread picks up
+	 * messages as soon as they're ready.
 	 */
-	void *get_queue()
-	{
-		static void *queue = []() {
-			void   *q;
-			Timeout t{UnlimitedTimeout};
-			int     ret =
-			  queue_create(&t, MALLOC_CAPABILITY, &q, 2 * sizeof(void *), 16);
-			assert(ret == 0);
-			return q;
-		}();
-		return queue;
-	}
+	RingBuffer<ThreadPoolMessage, 16, TicketLock, FlagLock> queue;
 
 } // namespace
 
@@ -34,41 +29,29 @@ int thread_pool_async(ThreadPoolCallback fn, void *data)
 	// The function must be sealed with the type used for export table entries
 	// for us to be able to invoke it.  The data capability doesn't *have* to
 	// be sealed, but it's a bad idea if it is unsealed because it adds the
-	// thread pool and scheduler to the TCB for confidentiality and integrity.
-	// This isn't a normal pointer check because we don't actually care about
-	// whether the data capability is usable, we just care that the caller is
-	// not leaking information.
+	// thread pool to the TCB for confidentiality and integrity.
+	// We want to avoid this being able to make us trap and so we validate that
+	// the function is cross-compartment entry point and both can be stored in
+	// the message queue.
 	if (!fnCap.is_valid() || (fnCap.type() != 9) ||
-	    (dataCap.is_valid() && !dataCap.is_sealed()))
+	    !fnCap.permissions().contains(Permission::Global) ||
+	    (dataCap.is_valid() && !dataCap.is_sealed()) ||
+	    (dataCap.is_valid() &&
+	     !dataCap.permissions().contains(Permission::Global)))
 	{
 		return -EINVAL;
 	}
 
-	void             *queue = get_queue();
-	ThreadPoolMessage message{fn, data};
-	int               ret;
-	Timeout           t{UnlimitedTimeout};
-	do
-	{
-		ret = queue_send(&t, queue, &message);
-	} while (ret == -ETIMEDOUT);
+	queue.push({fn, data});
 
 	return 0;
 }
 
 void __cheri_compartment("thread_pool") thread_pool_run()
 {
-	void             *queue = get_queue();
-	ThreadPoolMessage message;
-	Timeout           t{UnlimitedTimeout};
-
 	while (true)
 	{
-		// Retry until we get a message.
-		while (queue_recv(&t, queue, &message) < 0)
-		{
-			yield();
-		}
+		ThreadPoolMessage message = queue.pop();
 		message.invoke(message.data);
 	}
 }


### PR DESCRIPTION
This allows the thread pool to remove the scheduler from its TCB for confidentiality and integrity.

This exposes (and then fixes) a big in the thread list walking code.