### PR TITLE
Add a claims API to the allocator.

### DIFF
--- a/sdk/include/stdlib.h
+++ b/sdk/include/stdlib.h
@@ -137,6 +137,14 @@ void *__cheri_compartment("alloc")
                       size_t             size);
 
 /**
+ * Add a claim to an allocation.  The object will be counted against the quota
+ * provided by the first argument until a corresponding call to `heap_free`.
+ * Note that this can be used with interior pointers.
+ */
+size_t __cheri_compartment("alloc")
+  heap_claim(struct SObjStruct *heapCapability, void *pointer);
+
+/**
  * Free a heap allocation.
  *
  * Returns 0 on success, or `-EINVAL` if `ptr` is not a valid pointer to the


### PR DESCRIPTION
This makes it possible to claim a heap allocation so that it counts towards your quota (in addition to any other claims and the original owner's quota) and cannot be freed until everyone relinquishes their claims.

Claims can also apply to sub-objects and claim the entire object.

`heap_free` is a unified point for freeing and dropping claims.  This allows freeing heap pointers without worrying about who originally allocated them.