### PR TITLE
Add support for `xmake run`.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,14 +46,13 @@ jobs:
           xmake f --board=${{ matrix.board }} --sdk=/cheriot-tools/ ${{ matrix.build-flags }}
           xmake
         done
-    - name: Run tests
+    - name: Run examples 
       run: |
         set -e
         for example_dir in $PWD/examples/*/; do
           cd $example_dir
           echo Running $example_dir
-          example_name=$(basename ${example_dir#*.})
-          /cheriot-tools/bin/cheriot_sim -p --no-trace build/cheriot/cheriot/${{ matrix.build-type }}/${example_name}
+          xmake run
         done
 
   check-format:

--- a/docs/BoardDescriptions.md
+++ b/docs/BoardDescriptions.md
@@ -109,3 +109,16 @@ Optionally, it may include the string `$(sdk)`, which will be replaced by the fu
 For example, `"$(sdk)/include/platform/generic-riscv"` will expand to the generic RISC-V directory in the SDK.
 
 The driver headers use `#include_next` to include more generic files and so it is important to list the directories containing your overrides first.
+
+Simulation support
+------------------
+
+There are two properties for defining simulation platforms.
+If `simulation` is set to `true` then this board is assumed to be a simulation platform.
+This will make the `simulation_exit` function attempt to exit the simulator in case of catastrophic failures.
+
+In addition, the `simulator` property can be the name of a program (or script) that can simulate images compiled for this board.
+This will be run from the build directory and will be passed the absolute path of the firmware image when `xmake run` is used.
+The build system will look for the simulator in the SDK directory and, failing that, in the path.
+Exact paths can be provided by using `${sdk}` or `${board}` in the name of the simulator.
+These will be expanded to the full path of the SDK or the directory containing the board description file, respectively.

--- a/scripts/run-flute.sh
+++ b/scripts/run-flute.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+if [ -z "${FLUTE_BUILD}" ] ; then
+	echo The FLUTE_BUILD environment variable should be set to the flute build directory
+	exit 0
+fi
+# This script depends on non-portable GNU extensions, so prefer the g-prefixed
+# versions if they exist
+TAIL=tail
+if which gtail  ; then TAIL=gtail ; fi
+HEAD=head
+if which ghead  ; then HEAD=ghead ; fi
+PASTE=paste
+if which gpaste  ; then PASTE=gpaste ; fi
+echo Using ${TAIL}, ${HEAD}, and ${PASTE}
+
+if [ ! -f tail.hex ] ; then
+	for I in $(seq 0 32768) ; do
+		echo 00000000 >> tail.hex
+	done
+fi
+
+${FLUTE_BUILD}/../../Tests/elf_to_hex/elf_to_hex $1 Mem.hex
+
+awk '{print substr($0,33,8); print substr($0,0,8)}' Mem.hex > 1u-0.hex
+awk '{print substr($0,41,8); print substr($0,9,8)}' Mem.hex > 0u-0.hex
+awk '{print substr($0,49,8); print substr($0,17,8)}' Mem.hex > 1l-0.hex
+awk '{print substr($0,57,8); print substr($0,25,8)}' Mem.hex > 0l-0.hex
+
+${TAIL} -n +3 1u-0.hex > 1u-1.hex
+${TAIL} -n +3 0u-0.hex > 0u-1.hex
+${TAIL} -n +3 1l-0.hex > 1l-1.hex
+${TAIL} -n +3 0l-0.hex > 0l-1.hex
+
+${HEAD} -n -4 1u-1.hex > 1u-2.hex
+${HEAD} -n -4 0u-1.hex > 0u-2.hex
+${HEAD} -n -4 1l-1.hex > 1l-2.hex
+${HEAD} -n -4 0l-1.hex > 0l-2.hex
+
+${PASTE} -d \\n 1l-2.hex 1u-2.hex > 1-0.hex
+${PASTE} -d \\n 0l-2.hex 0u-2.hex > 0-0.hex
+
+cat 1-0.hex tail.hex | ${HEAD} -n 32768 > Mem-TCM-1.hex
+cat 0-0.hex tail.hex | ${HEAD} -n 32768 > Mem-TCM-0.hex
+
+${FLUTE_BUILD}/exe_HW_sim +tohost

--- a/sdk/boards/flute-debug-uart.json
+++ b/sdk/boards/flute-debug-uart.json
@@ -45,6 +45,7 @@
 	],
 	"timer_hz" : 40000,
 	"tickrate_hz" : 10,
+	"simulator" : "${sdk}/../scripts/run-flute.sh",
 	"simulation" : true
 }
 

--- a/sdk/boards/flute-no-revoker.json
+++ b/sdk/boards/flute-no-revoker.json
@@ -25,18 +25,17 @@
 	"heap" : {
 		"end"   : 0x80040000
 	},
-	"driver_includes" : [
-		"../include/platform/flute",
-		"../include/platform/generic-riscv"
-	],
 	"defines" : [
 		"FLUTE",
 		"FLUTE_SHADOW_BASE=0x40000000U",
 		"FLUTE_SHADOW_SIZE=0x1000U"
 	],
+	"driver_includes" : [
+		"../include/platform/flute",
+		"../include/platform/generic-riscv"
+	],
 	"timer_hz" : 40000,
 	"tickrate_hz" : 10,
-	"revoker" : "software",
 	"simulator" : "${sdk}/../scripts/run-flute.sh",
 	"simulation" : true
 }

--- a/sdk/boards/flute.json
+++ b/sdk/boards/flute.json
@@ -45,6 +45,7 @@
 	"timer_hz" : 40000,
 	"tickrate_hz" : 10,
 	"revoker" : "hardware",
+	"simulator" : "${sdk}/../scripts/run-flute.sh",
 	"simulation" : true
 }
 

--- a/sdk/boards/sail.json
+++ b/sdk/boards/sail.json
@@ -35,5 +35,6 @@
     "tickrate_hz" : 10,
     "revoker" : "software",
     "stack_high_water_mark" : true,
+    "simulator" : "cheriot_sim",
     "simulation": true
 }


### PR DESCRIPTION
This extends the board description file to be able to find the location of a simulator.
This also includes a script to convert ELF files to the hex dumps that Flute requires and to invoke the Flute simulator.

This also adds the missing flute config, for running benchmarks with the revoker disabled.