### PR TITLE
Attempt to fix problem with command run in dev container.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
     "xmake.workingDirectory": "${workspaceRoot}/tests",
     "xmake.additionalConfigArguments": "--sdk=/cheriot-tools/"
   },
-  "postAttachCommand": "git submodule init && git submodule update && cd tests && xmake f --sdk=/cheriot-tools/ && xmake project -k compile_commands .. && cd .. && for I in examples/[[:digit:]]* ; do echo $I ; cd $I ; xmake f --sdk=/cheriot-tools/ && xmake project -k compile_commands . && cd ../.. ; done",
+  "onCreateCommand": "git submodule init && git submodule update && cd tests && xmake f --sdk=/cheriot-tools/ && xmake project -k compile_commands .. && cd .. && for I in examples/[[:digit:]]* ; do echo $I ; cd $I ; xmake f --sdk=/cheriot-tools/ && xmake project -k compile_commands . && cd ../.. ; done",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
When creating a new github codespace the postAttachCommand from the devcontainer.json was not being run automatically. This might be because onCreateCommand is more appropriate.