### PR TITLE
Simplify compartment-call benchmark and make it more self consistent.

### DIFF
--- a/benchmarks/compartment-call/callee.cc
+++ b/benchmarks/compartment-call/callee.cc
@@ -1,10 +1,5 @@
 #include "callee.h"
 #include "../timing.h"
 
-void  noop() {}
-int  noop_return() { return rdcycle(); }
-int  noop_call(int start)
-{
-	return rdcycle() - start;
-}
+int  noop_return_rdcycle() { return rdcycle(); }
 

--- a/benchmarks/compartment-call/callee.h
+++ b/benchmarks/compartment-call/callee.h
@@ -1,5 +1,3 @@
 #include <compartment.h>
 
-void __cheri_compartment("callee") noop();
-int __cheri_compartment("callee") noop_return();
-int __cheri_compartment("callee") noop_call(int start);
+int __cheri_compartment("callee") noop_return_rdcycle();

--- a/benchmarks/compartment-call/caller.cc
+++ b/benchmarks/compartment-call/caller.cc
@@ -16,13 +16,10 @@ void __cheri_compartment("caller") run()
 		headerWritten = true;
 	}
 	auto [full, callPath, returnPath] = CHERI::with_interrupts_disabled([&]() {
-		auto full = rdcycle();
-		noop();
-		full = rdcycle() - full;
-		auto callPath = noop_call(rdcycle());
-		auto returnPath = noop_return();
-		returnPath = rdcycle() - returnPath;
-		return std::tuple{full, callPath, returnPath};
+		auto start = rdcycle();
+		auto middle = noop_return_rdcycle();
+		auto end = rdcycle();
+		return std::tuple{end - start, middle - start, end - middle};
 	});
 	size_t stackSize = get_stack_size();
 	out.format(__XSTRING(BOARD) "\t{}\t{}\t{}\t{}\n", stackSize, full, callPath, returnPath);


### PR DESCRIPTION
Due to the way the call and return costs for this benchmark were computed they didn't always add up to the total for the full call. We can eliminate this inconsistency by recording the start and end times on either side of the call and having the call return the time in the middle and computing the call and return times from this. The result is much simpler, sure to be self-consistent and the result for the full call is the same as before (at least on Sail) because reading the cycle counter simply takes the place of an instruction that otherwise placed zero into a0 for the 'noop' call.