### PR TITLE
Remove thread macros from the loader.

### DIFF
--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -31,8 +31,7 @@ riscv32-unknown-unknown
 -DDEVICE_EXISTS_shadow
 -DDEVICE_EXISTS_uart
 -DDEVICE_EXISTS_clint
--DCONFIG_THREADS={{1,2,1024,5},{2,1,1024,5},{3,1,1024,5},}
--DCONFIG_THREADS_ENTRYPOINTS={LA_ABS(__export_test_runner__Z9run_testsv),LA_ABS(__export_thread_pool__Z15thread_pool_runv),LA_ABS(__export_thread_pool__Z15thread_pool_runv),}
+-DCHERIOT_LOADER_TRUSTED_STACK_SIZE=208
 -DCONFIG_THREADS_NUM=3
 -DREVOKABLE_MEMORY_START=0x80000000
 -DCLANG_TIDY

--- a/sdk/core/loader/boot.S
+++ b/sdk/core/loader/boot.S
@@ -88,9 +88,19 @@ start:
 	cmove			ca3, ca4
 	cspecialrw		ca3, mscratchc, ca3
 	// ca4 still has the RW memory root; nothing to change
-	// The return value is SchedEntryInfo.
-	cincoffset		csp, csp, -16 - CONFIG_THREADS_NUM * BOOT_THREADINFO_SZ
-	csetbounds		ca0, csp, 16 + CONFIG_THREADS_NUM * BOOT_THREADINFO_SZ
+	// The return value is SchedEntryInfo, the space for it is in ca0
+	// See the comment at the start of `loader_entry_point` in `boot.cc`.
+
+	la_abs			s1, __thread_count
+	csetaddr		cs1, ca4, s1
+	clhu			s1, 0(cs1)
+	li			t0, -BOOT_THREADINFO_SZ
+	mul			s1, s1, t0
+	addi			s1, s1, -SchedulerEntryInfo_offset_threads
+
+	cincoffset		csp, csp, s1
+	neg			s1, s1
+	csetbounds		ca0, csp, s1
 
 	// Jump to loader_entry_point.
 	cjalr			cra
@@ -98,7 +108,7 @@ start:
 	// Load the two return values (pcc and cgp for the scheduler entry point)
 	clc				cs0, 0(csp)
 	clc				cgp, 8(csp)
-	cincoffset		csp, csp, 16
+	cincoffset		csp, csp, SchedulerEntryInfo_offset_threads
 
 	// Reset the stack pointer to point to the top and clear it
 	cgetbase		a0, csp
@@ -126,7 +136,8 @@ start:
 	// All other registers will be cleared in the clear-regs block
 
 	// Pass the array of threadInfos as first argument.
-	csetbounds		ca0, csp, CONFIG_THREADS_NUM * BOOT_THREADINFO_SZ
+	addi			s1, s1, -16
+	csetbounds		ca0, csp, s1
 
 .Lregs_clear:
 	// a0 is used to pass arguments to the scheduler entry.

--- a/sdk/core/loader/constants.h
+++ b/sdk/core/loader/constants.h
@@ -1,6 +1,7 @@
 // Copyright Microsoft and CHERIoT Contributors.
 // SPDX-License-Identifier: MIT
 
+#include <assembly-helpers.h>
 #define IMAGE_HEADER_LOADER_CODE_START_OFFSET 0
 #define IMAGE_HEADER_LOADER_CODE_SIZE_OFFSET 4
 #define IMAGE_HEADER_LOADER_DATA_START_OFFSET 6
@@ -8,33 +9,37 @@
 
 #ifdef __cplusplus
 #	include "types.h"
+#	include "../scheduler/common.h"
 namespace
 {
-	/**
-	 * Helper class for checking the size of a structure.  Used in static
-	 * asserts so that the expected size shows up in compiler error messages.
-	 */
-	template<size_t Real, size_t Expected>
-	struct CheckSize
+	/// The return type of the loader, to pass information to the scheduler.
+	struct SchedulerEntryInfo
 	{
-		static constexpr bool Value = Real == Expected;
+		/// scheduler initial entry point for thread initialisation
+		void *schedPCC;
+		/// scheduler CGP for thread initialisation
+		void *schedCGP;
+		/// thread descriptors for all threads
+		sched::ThreadLoaderInfo threads[];
 	};
 
 	using namespace loader;
 
 	static_assert(CheckSize<offsetof(ImgHdr, loader.code.startAddress),
-	                        IMAGE_HEADER_LOADER_CODE_START_OFFSET>::Value,
+	                        IMAGE_HEADER_LOADER_CODE_START_OFFSET>::value,
 	              "Offset of loader code start is incorrect");
 	static_assert(CheckSize<offsetof(ImgHdr, loader.code.smallSize),
-	                        IMAGE_HEADER_LOADER_CODE_SIZE_OFFSET>::Value,
+	                        IMAGE_HEADER_LOADER_CODE_SIZE_OFFSET>::value,
 	              "Offset of loader code size is incorrect");
 	static_assert(CheckSize<offsetof(ImgHdr, loader.data.startAddress),
-	                        IMAGE_HEADER_LOADER_DATA_START_OFFSET>::Value,
+	                        IMAGE_HEADER_LOADER_DATA_START_OFFSET>::value,
 	              "Offset of loader data start is incorrect");
 	static_assert(CheckSize<offsetof(ImgHdr, loader.data.smallSize),
-	                        IMAGE_HEADER_LOADER_DATA_SIZE_OFFSET>::Value,
+	                        IMAGE_HEADER_LOADER_DATA_SIZE_OFFSET>::value,
 	              "Offset of loader data size is incorrect");
-	static_assert(CheckSize<offsetof(ImgHdr, switcher.entryPoint), 18>::Value,
+	static_assert(CheckSize<offsetof(ImgHdr, switcher.entryPoint), 18>::value,
 	              "Offset of loader data size is incorrect");
 } // namespace
 #endif
+
+EXPORT_ASSEMBLY_OFFSET(SchedulerEntryInfo, threads, 16);

--- a/sdk/core/scheduler/common.h
+++ b/sdk/core/scheduler/common.h
@@ -145,8 +145,6 @@ namespace sched
 		/// The trusted stack for this thread. This field should be sealed by
 		/// the loader and contain populated PCC, CGP and CSP caps.
 		TrustedStack *trustedStack;
-		/// Thread ID. Certain compartments need to know which thread it is in.
-		uint16_t threadid;
 		/// Thread priority. The higher the more prioritised.
 		uint16_t priority;
 	};

--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -124,8 +124,10 @@ namespace sched
 
 		for (size_t i = 0; auto *threadSpace : threadSpaces)
 		{
+			Debug::log("Created thread for trusted stack {}",
+			           info[i].trustedStack);
 			Thread *th = new (threadSpace)
-			  Thread(info[i].trustedStack, info[i].threadid, info[i].priority);
+			  Thread(info[i].trustedStack, i + 1, info[i].priority);
 			th->ready(Thread::WakeReason::Timer);
 			i++;
 		}

--- a/sdk/firmware.ldscript.in
+++ b/sdk/firmware.ldscript.in
@@ -13,10 +13,11 @@ SECTIONS
 		*(.loader_start);
 	}
 
-	.thread_stacks (NOLOAD) :  ALIGN(0x10)
-	{
-		*(.thread_stacks);
-	}
+	@thread_trusted_stacks@
+
+	__stack_space_start = .;
+	@thread_stacks@
+	__stack_space_end = .;
 
 	.compartment_export_tables : ALIGN(8)
 	{
@@ -192,11 +193,23 @@ SECTIONS
 		SHORT(@library_count@);
 		# Number of compartment headers.
 		SHORT(@compartment_count@);
-
 		@compartment_headers@
+	}
 
+	# Thread configuration.  This follows the compartment headers but is in a
+	# separate section to make auditing easier.
+	# This section holds a `class ThreadInfo` (loader/types.h)
+	.thread_config :
+	{
+		.thread_config_start = .;
+		# Number of threads
+		__thread_count = .;
+		SHORT(@thread_count@);
+		# The thread structures
+		@thread_headers@
 		__compart_headers_end = .;
 	}
+
 
 	.loader_code : CAPALIGN
 	{


### PR DESCRIPTION
The loader was initialising threads given two (fairly complex) macros passed via `-D` at compile time.  This caused two problems for auditing:

 - The loader .o files were different depending on thread configuration.
 - The description of threads was interleaved in the loader and hard to separate.

In the new structure, the unlinked loader binaries should be identical for all firmware images.  After linking, they will embed the address of the image header (which should make the hashes of the linked version predictable by anyone who has a copy of the unlinked binary).  All of the thread information now lives in the .thread_config section and so is amenable to being added to the linker report (not done yet).

This also removes the bump allocator from the loader.  This caused some problems with certain stack sizes because it didn't really understand representability.  The build system now puts each stack and trusted stack in a separate section and uses the `CAPALIGN` directive to ensure that they're padded sufficiently.  In a future version, it might sort these by size to ensure that they're in the most efficient order to minimise padding (though in the common case, none of them require padding).