### PR TITLE
Enforce stack-size limit.

### DIFF
--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -406,7 +406,7 @@ rule("firmware")
 			"\n\t\t. += " .. loader_trusted_stack_size .. ";" ..
 			"\n\t}\n"
 		-- Stacks must be less than this size or truncating them in compartment
-		-- switch will encounter precision errors.
+		-- switch may encounter precision errors.
 		local stack_size_limit = 8176
 		for i, thread in ipairs(threads) do
 			thread.mangled_entry_point = string.format("__export_%s__Z%d%sv", thread.compartment, string.len(thread.entry_point), thread.entry_point)


### PR DESCRIPTION
The compartment switcher will not behave correctly if subsetting a stack results in something unrepresentable.  We can avoid this by limiting stacks to the maximum representable size for 16-byte alignment.

Eventually this can be removed if we make the switcher round the shared bit of the stack down to avoid overlap.  At the moment, it's not a serious limitation because our stacks are very rarely over 1 KiB and the limit is about 8 KiB.

Fixes #58