### PR TITLE
Add `heap_free_all`.

### DIFF
--- a/sdk/include/stdlib.h
+++ b/sdk/include/stdlib.h
@@ -155,6 +155,15 @@ int __cheri_compartment("alloc")
   heap_free(struct SObjStruct *heapCapability, void *ptr);
 
 /**
+ * Free all allocations owned by this capability.
+ *
+ * Returns the number of bytes freed or `-EPERM` if this is not a valid heap
+ * capability.
+ */
+ssize_t __cheri_compartment("alloc")
+  heap_free_all(struct SObjStruct *heapCapability);
+
+/**
  * Returns 0 if the allocation can be freed with the given capability, a
  * negated errno value otherwise.
  */


### PR DESCRIPTION
This API takes a heap capability and frees *all* memory that can be freed by that capability.

The current implementation holds the heap lock for the entire heap walk. This may not be ideal but it's somewhat complex to avoid.  We would need to ensure that the chunk that we are currently inspecting is not coalesced when we yield.