### PR TITLE
Update the devcontainer location.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,7 @@
 {
-  "image": "cheriot.azurecr.io/cheriot/devcontainer",
+  "image": "ghcr.io/cheriot-platform/devcontainer:latest",
   "remoteUser": "cheriot",
   "containerUser": "cheriot",
-  "settings": {
-    "clangd.path": "/cheriot-tools/bin/clangd",
-    "xmake.compileCommandsDirectory": "${workspaceRoot}",
-    "xmake.workingDirectory": "${workspaceRoot}/tests",
-    "xmake.additionalConfigArguments": "--sdk=/cheriot-tools/"
-  },
   "onCreateCommand": "git submodule init && git submodule update && cd tests && xmake f --sdk=/cheriot-tools/ && xmake project -k compile_commands .. && cd .. && for I in examples/[[:digit:]]* ; do echo $I ; cd $I ; xmake f --sdk=/cheriot-tools/ && xmake project -k compile_commands . && cd ../.. ; done",
   "customizations": {
     "vscode": {
@@ -15,7 +9,13 @@
           "llvm-vs-code-extensions.vscode-clangd",
           "tboox.xmake-vscode",
           "hnw.vscode-auto-open-markdown-preview"
-      ]
+      ],
+      "settings": {
+        "clangd.path": "/cheriot-tools/bin/clangd",
+        "xmake.compileCommandsDirectory": "${workspaceRoot}",
+        "xmake.workingDirectory": "${workspaceRoot}/tests",
+        "xmake.additionalConfigArguments": "--sdk=/cheriot-tools/"
+      }
     }
   }
 }


### PR DESCRIPTION
The old dev container was built by an Azure Pipelines job backed by an Azure Scale Set.  Unfortunately, Azure Scale Sets don't allow you to replace the VM image and the Ubuntu one that we were using went away.  Since I have left Microsoft, there are no people who both know how to fix this problem and have the required access.

I have set up public CI with Cirrus-CI.  This now does pre-merge testing for LLVM and also builds container images for both x86-64 and AArch64.  This PR updates the devcontainer path to point to that image.  It also fixes an error pointed out by VS Code in the location of settings for the devcontainer.