### PR TITLE
Clean up library exports

### DIFF
--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -1067,10 +1067,12 @@ extern "C" SchedulerEntryInfo loader_entry_point(const ImgHdr &imgHdr,
 	// exposed as a normal export, which enables exporting other things from
 	// the switcher later.
 	Debug::log("Setting compartment switcher");
-	auto switcherEntry = build<ExportEntry>(imgHdr.switcher.exportTable.start() + 20, imgHdr.switcher.exportTable.size());
-	switcherPCC.address() =
-	  switcherPCC.base() + switcherEntry->functionStart;
-	Debug::log("Setting compartment switcher address: {}", switcherPCC.address());
+	auto switcherEntry =
+	  build<ExportEntry>(imgHdr.switcher.exportTable.start() + 20,
+	                     imgHdr.switcher.exportTable.size());
+	switcherPCC.address() = switcherPCC.base() + switcherEntry->functionStart;
+	Debug::log("Setting compartment switcher address: {}",
+	           switcherPCC.address());
 	switcherPCC = seal_entry(switcherPCC, InterruptStatus::Disabled);
 
 	auto setSealingKey =

--- a/sdk/core/loader/constants.h
+++ b/sdk/core/loader/constants.h
@@ -37,8 +37,6 @@ namespace
 	static_assert(CheckSize<offsetof(ImgHdr, loader.data.smallSize),
 	                        IMAGE_HEADER_LOADER_DATA_SIZE_OFFSET>::value,
 	              "Offset of loader data size is incorrect");
-	static_assert(CheckSize<offsetof(ImgHdr, switcher.entryPoint), 18>::value,
-	              "Offset of loader data size is incorrect");
 } // namespace
 #endif
 

--- a/sdk/core/loader/types.h
+++ b/sdk/core/loader/types.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../switcher/tstack.h"
+#include "assembly-helpers.h"
 #include "defines.h"
 #include <cdefs.h>
 #include <cheri.hh>
@@ -362,11 +363,6 @@ namespace loader
 			AddressRange code;
 
 			/**
-			 * The offset relative to the PCC of the switcher's entry point.
-			 */
-			uint16_t entryPoint;
-
-			/**
 			 * The PCC-relative location of the sealing key, which the
 			 * compartment switcher will use to unseal import table entries.
 			 */
@@ -392,12 +388,10 @@ namespace loader
 			uint16_t schedulerCSP;
 
 			/**
-			 * The entry point as a full address.
+			 * Export table start location.  The first export is the
+			 * compartment switcher entry point.
 			 */
-			[[nodiscard]] ptraddr_t entry_point() const
-			{
-				return code.start() + entryPoint;
-			}
+			AddressRange exportTable;
 
 			/**
 			 * The location of the sealing key as a full address.
@@ -618,7 +612,7 @@ namespace loader
 			// This is a random 32-bit number and should be changed whenever
 			// the compartment header layout changes to provide some sanity
 			// checking.
-			return magic == 0x43f6af90;
+			return magic == 0x6cef3879;
 		}
 
 		/**
@@ -905,8 +899,10 @@ namespace loader
 
 	/**
 	 * The header of an export table.
+	 *
+	 * This is followed by an array of `ExportEntry`.
 	 */
-	struct ExportTableHeader
+	struct ExportTable
 	{
 		/**
 		 * The compartment's $pcc.
@@ -1011,17 +1007,6 @@ namespace loader
 		}
 	};
 
-	/**
-	 * Export table.  This is the full export table, including the header and
-	 * the entries.
-	 */
-	struct ExportTable : public ExportTableHeader
-	{
-		/**
-		 * The export entries in this table.
-		 */
-		ExportEntry entries[];
-	};
 
 #include "../switcher/export-table-assembly.h"
 } // namespace loader

--- a/sdk/core/loader/types.h
+++ b/sdk/core/loader/types.h
@@ -1007,6 +1007,5 @@ namespace loader
 		}
 	};
 
-
 #include "../switcher/export-table-assembly.h"
 } // namespace loader

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -146,10 +146,10 @@ switcher_scheduler_entry_csp:
 .endm
 
 	.section .text, "ax", @progbits
-	.globl compartment_switcher_entry
+	.globl __Z26compartment_switcher_entryz
 	.p2align 2
-	.type compartment_switcher_entry,@function
-compartment_switcher_entry:
+	.type __Z26compartment_switcher_entryz,@function
+__Z26compartment_switcher_entryz:
 	cincoffset        csp, csp, -SPILL_SLOT_SIZE
 	csc               cs0, SPILL_SLOT_cs0(csp)
 	csc               cs1, SPILL_SLOT_cs1(csp)
@@ -779,3 +779,16 @@ exception_entry_asm:
 #endif
 #endif // CONFIG_NO_SWITCHER_SAFETY
 	cret
+
+	.section	.compartment_export_table,"a",@progbits
+	.type	__export_switcher__Z26compartment_switcher_entryz,@object
+	.globl	__export_switcher__Z26compartment_switcher_entryz
+	.p2align	2
+__export_switcher__Z26compartment_switcher_entryz:
+	.half	__Z26compartment_switcher_entryz-compartment_switcher_sealing_key
+	// Number of registers to clear (ignored for library exports)
+	.byte	0
+	// Interrupts disabled.
+	.byte	16
+	.size	__export_switcher__Z26compartment_switcher_entryz, 4
+

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -780,7 +780,15 @@ exception_entry_asm:
 #endif // CONFIG_NO_SWITCHER_SAFETY
 	cret
 
+
+// The linker expects export tables to start with space for cgp and pcc, then
+// the compartment error handler.  We should eventually remove that requirement
+// for library export tables, but since they don't consume RAM after loading
+// it's not urgent.
 	.section	.compartment_export_table,"a",@progbits
+export_table_start:
+.space 20, 0
+
 	.type	__export_switcher__Z26compartment_switcher_entryz,@object
 	.globl	__export_switcher__Z26compartment_switcher_entryz
 	.p2align	2

--- a/sdk/firmware.ldscript.in
+++ b/sdk/firmware.ldscript.in
@@ -21,8 +21,6 @@ SECTIONS
 
 	.compartment_export_tables : ALIGN(8)
 	{
-		__compart_exports = .;
-
 		# The scheduler and allocator's export tables are at the start.
 		.scheduler_export_table = .;
 		*.scheduler.compartment(.compartment_export_table);
@@ -31,14 +29,6 @@ SECTIONS
 		.allocator_export_table = ALIGN(8);
 		*/cherimcu.allocator.compartment(.compartment_export_table);
 		.allocator_export_table_end = .;
-
-		.token_library_export_table = ALIGN(8);
-		*/cheriot.token_library.library(.compartment_export_table);
-		.token_library_export_table_end = .;
-
-		.switcher_export_table = ALIGN(8);
-		*/switcher/entry.S.o(.compartment_export_table);
-		.switcher_export_table_end = .;
 
 		@compartment_exports@
 	}
@@ -283,6 +273,19 @@ SECTIONS
 		*/loader/boot.cc.o(.data .data.* .sdata .sdata.* .sbss .sbss.* .bss .bss.*);
 	}
 	.loader_data_end = .;
+
+	.library_export_tables : ALIGN(8)
+	{
+		.token_library_export_table = ALIGN(8);
+		*/cheriot.token_library.library(.compartment_export_table);
+		.token_library_export_table_end = .;
+
+		.switcher_export_table = ALIGN(8);
+		*/switcher/entry.S.o(.compartment_export_table);
+		.switcher_export_table_end = .;
+
+		@library_exports@
+	}
 
 }
 # No symbols should be exported

--- a/sdk/firmware.ldscript.in
+++ b/sdk/firmware.ldscript.in
@@ -36,6 +36,10 @@ SECTIONS
 		*/cheriot.token_library.library(.compartment_export_table);
 		.token_library_export_table_end = .;
 
+		.switcher_export_table = ALIGN(8);
+		*/switcher/entry.S.o(.compartment_export_table);
+		.switcher_export_table_end = .;
+
 		@compartment_exports@
 	}
 
@@ -45,7 +49,7 @@ SECTIONS
 	compartment_switcher_code : CAPALIGN
 	{
 		.compartment_switcher_start = .;
-		*/switcher/*.o(.text);
+		*/switcher/entry.S.o(.text);
 	}
 	.compartment_switcher_end = .;
 
@@ -68,6 +72,7 @@ SECTIONS
 	}
 	.allocator_end = .;
 
+
 	token_library_code : CAPALIGN
 	{
 		.token_library_start = .;
@@ -77,6 +82,7 @@ SECTIONS
 		*/cheriot.token_library.library(.text .text.* .rodata .rodata.* .data.rel.ro);
 	}
 	.token_library_end = .;
+
 
 	@software_revoker_code@
 
@@ -165,8 +171,6 @@ SECTIONS
 		LONG(.compartment_switcher_start);
 		# Compartment switcher end
 		SHORT(.compartment_switcher_end - .compartment_switcher_start);
-		# Compartment switcher entry point offset
-		SHORT(compartment_switcher_entry - .compartment_switcher_start);
 		# Compartment switcher sealing key
 		SHORT(compartment_switcher_sealing_key - .compartment_switcher_start);
 		# Switcher's copy of the scheduler's PCC.
@@ -175,6 +179,10 @@ SECTIONS
 		SHORT(switcher_scheduler_entry_cgp - .compartment_switcher_start);
 		# Switcher's copy of the scheduler's CSP
 		SHORT(switcher_scheduler_entry_csp - .compartment_switcher_start);
+		# Address of switcher export table
+		LONG(.switcher_export_table);
+		# Size of the switcher export table
+		SHORT(.switcher_export_table_end - .switcher_export_table);
 
 		# sdk/core/loader/types.h:/PrivilegedCompartment
 		# Scheduler code start address
@@ -234,8 +242,12 @@ SECTIONS
 
 		@software_revoker_header@
 
-		# Magic number
-		LONG(0x43f6af90);
+		# sdk/core/loader/types.h:/is_magic_valid
+		# Magic number, used to detect mismatches between linker script and
+		# loader versions.
+		# New versions of this can be generated with:
+		# head /dev/random | shasum | cut -c 0-8
+		LONG(0x6cef3879);
 		# Number of library headers.
 		SHORT(@library_count@);
 		# Number of compartment headers.

--- a/sdk/library.ldscript
+++ b/sdk/library.ldscript
@@ -6,10 +6,10 @@ SECTIONS
 	. = 0;
 	.compartment_export_table : ALIGN(8)
 	{
-		# Space for the compartment's PCC and GDC
+		# Space for the compartment's PCC and GDC.
 		. = . + 16;
-		# Space for the compartment's ID
-		. = . + 2;
+		# Space for the error handler.
+		. = . + 4;
 		# Array of compartment exports
 		*(.compartment_exports);
 	}

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -519,7 +519,7 @@ rule("firmware")
 				"\n\t\tSHORT(.${compartment}_sealed_objects_end - .${compartment}_sealed_objects_start);\n",
 			pcc_ld = compartment_templates.pcc_ld,
 			gdc_ld = "",
-			compartment_exports = compartment_templates.compartment_exports,
+			library_exports = compartment_templates.compartment_exports,
 			cap_relocs = compartment_templates.cap_relocs,
 			sealed_objects = compartment_templates.sealed_objects
 		}
@@ -527,6 +527,7 @@ rule("firmware")
 		-- script.  Initialised as empty strings.
 		local ldscript_substitutions = {
 			compartment_exports="",
+			library_exports="",
 			cap_relocs="",
 			compartment_headers="",
 			pcc_ld="",


### PR DESCRIPTION
This contains two commits.  The first makes the switcher entry point a real export.  This is a starting point for adding other exports from the switcher (for example, debugging facilities to get a compartment stack trace or to query the amount of trusted stack depth available).

The second moves library export tables (including the switcher ones) to the heap region, since they're not needed after loading.

This will fail in CI until CHERIoT-Platform/llvm-project#3 is merged.