### PR TITLE
Update LLVM build instructions

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -118,14 +118,14 @@ Next create a directory for the build and enter it:
 
 ```sh
 $ mkdir -p builds/cheriot-llvm
-$ cd builds/llvm
+$ cd builds/cheriot-llvm
 ```
 
 This can be inside the source checkout but you may prefer to build somewhere else, for example on a different filesystem.
 Next, use `cmake` to configure the build:
 
 ```sh
-$ cmake ${LLVM_PATH} -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld" -   DCMAKE_INSTALL_PREFIX=install -DLLVM_ENABLE_UNWIND_TABLES=NO -DLLVM_ENABLE_LLD=ON -DLLVM_TARGETS_TO_BUILD=RISCV -       DLLVM_DISTRIBUTION_COMPONENTS="clang;clangd;lld;llvm-objdump" -G Ninja
+$ cmake ${LLVM_PATH}/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld" -DCMAKE_INSTALL_PREFIX=install -DLLVM_ENABLE_UNWIND_TABLES=NO -DLLVM_TARGETS_TO_BUILD=RISCV -DLLVM_DISTRIBUTION_COMPONENTS="clang;clangd;lld;llvm-objdump" -G Ninja
 ```
 
 It is very strongly recommended that you do a release build, debug builds can take several minutes to compile files that take seconds with release builds.


### PR DESCRIPTION
First is a minor fix of directory name from `llvm` to `cheriot-llvm`.
Second is some fixes to the `cmake` command:
- `${LLVM_PATH}` needs to be followed by `llvm` to find the correct folder.
- Remove some extra spaces in the command argumetns.
- Remove `LLVM_ENABLE_LLD` to resolve the following error on GCC
platforms:
```
CMake Error at cmake/modules/HandleLLVMOptions.cmake:298 (message):
  Host compiler does not support '-fuse-ld=lld'
```