### PR TITLE
Add support for the Ibex in the SAFE configuration.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix: 
         build-type: [ debug, release ]
-        board: [ sail ]
+        board: [ sail, ibex-safe-simulator ]
         include:
           - build-type: debug
             build-flags: --debug-loader=y --debug-scheduler=y --debug-allocator=y -m debug
@@ -36,7 +36,7 @@ jobs:
     - name: Run tests
       run: |
         cd tests
-        /cheriot-tools/bin/cheriot_sim -p --no-trace build/cheriot/cheriot/${{ matrix.build-type }}/test-suite
+        xmake run
     - name: Build examples
       run: |
         set -e
@@ -52,7 +52,9 @@ jobs:
         for example_dir in $PWD/examples/*/; do
           cd $example_dir
           echo Running $example_dir
-          xmake run
+          if [ ${{ matrix.board }} = sail ]; then
+            xmake run
+          fi
         done
 
   check-format:

--- a/scripts/run-ibex-safe-sim.sh
+++ b/scripts/run-ibex-safe-sim.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Find objcopy.
+OBJCOPY=llvm-objcopy
+if ! type ${OBJCOPY} >/dev/null 2>&1 ; then
+	if [ -x "/cheriot-tools/bin/llvm-objcopy" ] ; then
+		OBJCOPY=/cheriot-tools/bin/llvm-objcopy
+	else
+		if [ -n "${TOOLS_PATH}" ] ; then
+			if [ -x "${TOOLS_PATH}/llvm-objcopy" ] ; then
+				echo found TOOLS_PATH/llvm-objcopy
+				OBJCOPY=${TOOLS_PATH}/llvm-objcopy
+			fi
+		fi
+	fi
+fi
+
+if [ ! -x ${OBJCOPY} ] ; then
+	echo Unable to locate llvm-objcopy, please set TOOLS_PATH to the directory containing the LLVM toolchain.
+	exit 1
+fi
+
+if [ -z ${CHERIOT_IBEX_SAFE_SIM} ] ; then
+	CHERIOT_IBEX_SAFE_SIM=/cheriot-tools/bin/cheriot_ibex_safe_sim
+fi
+
+if [ ! -x ${CHERIOT_IBEX_SAFE_SIM} ] ; then
+	echo Unable to locate simulator, please set CHERIOT_IBEX_SAFE_SIM to the full path to the simulator.
+	exit 1
+fi
+
+# Prepare the firmware directory with an IROM that just contains a single jump
+# instruction that branches to the start of IRAM
+if [ ! -d firmware ] ; then
+	mkdir firmware
+	for I in `seq 32` ; do
+		echo 00000000 >> firmware/cpu0_irom.vhx
+	done
+	# jump forward to the start of IRAM
+	echo 7813f06f >> firmware/cpu0_irom.vhx
+fi
+
+# Convert the ELF file to a hex file for the simulator
+${OBJCOPY} -O binary $1 - | hexdump -v -e '"%08X" "\n"' > firmware/cpu0_iram.vhx
+
+# Run the simulator.
+${CHERIOT_IBEX_SAFE_SIM}

--- a/sdk/boards/ibex-safe-simulator.json
+++ b/sdk/boards/ibex-safe-simulator.json
@@ -1,0 +1,52 @@
+{
+    "devices": {
+        "clint": {
+            "start": 0x14001000,
+            "length": 0x1000
+        },
+        "plic": {
+            "start": 0x10000000,
+            "end": 0x10400000
+        },
+        "revoker": {
+            "start": 0x14000000,
+            "length": 0x1000
+        },
+        "uart": {
+            "start": 0x8f00b000,
+            "end":   0x8f00b100
+        },
+        "shadow" : {
+            "start": 0x200fe000,
+            "length": 0x2000
+        }
+    },
+    "instruction_memory": {
+        "start": 0x20040000,
+        "end": 0x20080000
+    },
+    "heap": {
+        "end": 0x20080000
+    },
+    "interrupts": [
+        {
+            "name": "RevokerInterrupt",
+            "number": 1,
+            "priority": 2
+        }
+    ],
+    "defines" : [
+        "IBEX",
+        "IBEX_SAFE"
+    ],
+    "driver_includes" : [
+        "../include/platform/generic-riscv",
+        "../include/platform/ibex"
+    ],
+    "timer_hz" : 100000,
+    "tickrate_hz" : 10,
+    "revoker" : "hardware",
+    "stack_high_water_mark" : true,
+    "simulation": true,
+    "simulator" : "${sdk}/../scripts/run-ibex-safe-sim.sh"
+}

--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -41,8 +41,13 @@ volatile uint32_t tohost[2];
  */
 void simulation_exit(uint32_t code)
 {
+	// If this is using the standard RISC-V to-host mechanism, this will exit.
 	tohost[0] = 0x1 | (code << 1);
 	tohost[1] = 0;
+	// If we didn't exit with to-host, try writing a non-ASCII character to the
+	// UART.  This is how we exit the CHERIoT Ibex simulator for the SAFE
+	// platform.
+	MMIO_CAPABILITY(Uart, uart)->blocking_write(0x80 + code);
 }
 
 #endif

--- a/sdk/include/platform/generic-riscv/platform-timer.hh
+++ b/sdk/include/platform/generic-riscv/platform-timer.hh
@@ -76,8 +76,22 @@ class StandardClint : private utils::NoCopyNoMove
 	}
 
 	private:
+#ifdef IBEX_SAFE
+	/**
+	 * The Ibex-SAFE platform doesn't implement a complete CLINT, only the
+	 * timer part (which is all that we use).  Its offsets within the CLINT
+	 * region are different.
+	 */
+	static constexpr size_t ClintMtime    = 0x10;
+	static constexpr size_t ClintMtimecmp = 0x18;
+#else
+	/**
+	 * The standard RISC-V CLINT is a large memory-mapped device and places the
+	 * timers a long way in.
+	 */
 	static constexpr size_t ClintMtimecmp = 0x4000U;
 	static constexpr size_t ClintMtime    = 0xbff8U;
+#endif
 
 	static inline volatile uint32_t *pmtimercmp;
 	static inline volatile uint32_t *pmtimer;

--- a/sdk/include/platform/generic-riscv/platform-uart.hh
+++ b/sdk/include/platform/generic-riscv/platform-uart.hh
@@ -95,7 +95,13 @@ class Uart16550
 	 */
 	__always_inline bool can_write() volatile
 	{
+#ifdef SIMULATION
+		// If we're in a simulator, we're running *much* slower than the thing
+		// handling the UART, so assume that you can always write to the UART.
+		return true;
+#else
 		return LineStatus & (1 << 5);
+#endif
 	}
 
 	/**


### PR DESCRIPTION
This adds the board description and a script for running firmware images.  It's now possible to target the Ibex simulator with `--board=ibex-safe-simulator` and then run with `xmake run`.

This includes a few other changes:

 - In simulation environments, don't poll for the UART to be ready to write.  It always is and removing the loop speeds up output a *lot*.
 - The Ibex simulator does not support the tohost magic (this is hard to support in any simulator that doesn't read ELF files) and exits by writing a byte with the top bit set to the UART.  In `simulation_exit`, we try that after the write to the tohost
 - The Ibex doesn't have a full CLINT, only the registers that we use. Rather than providing a separate CLIT driver, there's now an ifdef for choosing the locations of the two variations.
 - The Ibex revoker's interface was significantly improved but no hardware was available for testing the new version.  This commit deletes a load of code that the new interface has made obsolete.
 - CI should now run with Ibex as well as Sail.

Huge thanks to @kliuMsft for all of the Ibex work that made this possible.