### PR TITLE
Run apt-update before installing things.

### DIFF
--- a/exercises/01.compartmentalisation/load_js.sh
+++ b/exercises/01.compartmentalisation/load_js.sh
@@ -17,6 +17,7 @@ if [ ! -f ./node_modules/.bin/microvium ] ; then
 		if type apt >/dev/null 2>&1 ; then
 			echo npm is not installed.  Trying to install it from apt.
 			echo If you are not using the devcontainer, this may fail.
+			sudo apt update
 			sudo apt install nodejs make gcc g++
 		else
 			echo npm is not installed.  Please install it.


### PR DESCRIPTION
If you don't, apt will use stale indexes and then fail in the installation because the package repo state doesn't match what it expects.