### PR TITLE
Add a platform description for the A7.

### DIFF
--- a/scripts/ibex-build-firmware.sh
+++ b/scripts/ibex-build-firmware.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Find objcopy.
+OBJCOPY=llvm-objcopy
+if ! type ${OBJCOPY} >/dev/null 2>&1 ; then
+	if [ -x "/cheriot-tools/bin/llvm-objcopy" ] ; then
+		OBJCOPY=/cheriot-tools/bin/llvm-objcopy
+	else
+		if [ -n "${TOOLS_PATH}" ] ; then
+			if [ -x "${TOOLS_PATH}/llvm-objcopy" ] ; then
+				echo found ${TOOLS_PATH}/llvm-objcopy
+				OBJCOPY=${TOOLS_PATH}/llvm-objcopy
+			fi
+		fi
+	fi
+fi
+
+if [ ! -x ${OBJCOPY} ] ; then
+	echo Unable to locate llvm-objcopy, please set TOOLS_PATH to the directory containing the LLVM toolchain.
+	exit 1
+fi
+
+echo Using ${OBJCOPY}...
+
+# Convert the ELF file to a hex file for the simulator
+${OBJCOPY} -O binary $1 - | hexdump -v -e '"%08X" "\n"' > firmware/cpu0_iram.vhx
+# Add a newline at the end of the vhx file
+echo >> firmware/cpu0_iram.vhx

--- a/scripts/run-ibex-safe-sim.sh
+++ b/scripts/run-ibex-safe-sim.sh
@@ -1,24 +1,6 @@
 #!/bin/sh
 
-# Find objcopy.
-OBJCOPY=llvm-objcopy
-if ! type ${OBJCOPY} >/dev/null 2>&1 ; then
-	if [ -x "/cheriot-tools/bin/llvm-objcopy" ] ; then
-		OBJCOPY=/cheriot-tools/bin/llvm-objcopy
-	else
-		if [ -n "${TOOLS_PATH}" ] ; then
-			if [ -x "${TOOLS_PATH}/llvm-objcopy" ] ; then
-				echo found TOOLS_PATH/llvm-objcopy
-				OBJCOPY=${TOOLS_PATH}/llvm-objcopy
-			fi
-		fi
-	fi
-fi
-
-if [ ! -x ${OBJCOPY} ] ; then
-	echo Unable to locate llvm-objcopy, please set TOOLS_PATH to the directory containing the LLVM toolchain.
-	exit 1
-fi
+set -e
 
 if [ -z ${CHERIOT_IBEX_SAFE_SIM} ] ; then
 	CHERIOT_IBEX_SAFE_SIM=/cheriot-tools/bin/cheriot_ibex_safe_sim
@@ -33,15 +15,16 @@ fi
 # instruction that branches to the start of IRAM
 if [ ! -d firmware ] ; then
 	mkdir firmware
+	# The start of IROM is a vectored interrupt table.
 	for I in `seq 32` ; do
 		echo 00000000 >> firmware/cpu0_irom.vhx
 	done
-	# jump forward to the start of IRAM
+	# Offset 0x80 is the entry point.  Insert a single relative jump here that
+	# jumps to the start of IRAM.
 	echo 7813f06f >> firmware/cpu0_irom.vhx
 fi
 
-# Convert the ELF file to a hex file for the simulator
-${OBJCOPY} -O binary $1 - | hexdump -v -e '"%08X" "\n"' > firmware/cpu0_iram.vhx
+$(dirname $0)/ibex-build-firmware.sh $1
 
 # Run the simulator.
 ${CHERIOT_IBEX_SAFE_SIM}

--- a/sdk/boards/ibex-arty-a7-100.json
+++ b/sdk/boards/ibex-arty-a7-100.json
@@ -1,0 +1,62 @@
+{
+    "devices": {
+        "clint": {
+            "start": 0x14001000,
+            "length": 0x1000
+        },
+        "plic": {
+            "start": 0x10000000,
+            "end": 0x10400000
+        },
+        "revoker": {
+            "start": 0x14000000,
+            "length": 0x1000
+        },
+        "uart": {
+            "start": 0x8f00b000,
+            "end":   0x8f00b100
+        },
+        "shadow" : {
+            "start": 0x200fe000,
+            "length": 0x2000
+        },
+        "gpio_led0" : {
+            "start": 0x8f00f000,
+            "length": 0x800
+        }
+    },
+    "instruction_memory": {
+        "start": 0x20040000,
+        "end": 0x20080000
+    },
+    "heap": {
+        "end": 0x20080000
+    },
+    "interrupts": [
+        {
+            "name": "RevokerInterrupt",
+            "number": 1,
+            "priority": 2
+        },
+        {
+            "name": "UARTInterrupt",
+            "number": 2,
+            "priority": 3,
+            "edge_triggered": true
+        }
+    ],
+    "defines" : [
+        "IBEX",
+        "IBEX_SAFE"
+    ],
+    "driver_includes" : [
+        "${sdk}/include/platform/arty-a7",
+        "${sdk}/include/platform/synopsis",
+        "${sdk}/include/platform/ibex",
+        "${sdk}/include/platform/generic-riscv"
+    ],
+    "timer_hz" : 20000000,
+    "tickrate_hz" : 100,
+    "revoker" : "hardware",
+    "stack_high_water_mark" : true
+}

--- a/sdk/include/platform/arty-a7/platform-gpio.hh
+++ b/sdk/include/platform/arty-a7/platform-gpio.hh
@@ -1,0 +1,177 @@
+#pragma once
+#include <cdefs.h>
+#include <stdint.h>
+
+/**
+ * The Arty A7 configuration has two LEDs exposed over GPIO.
+ *
+ * This provides a simple driver for them.
+ */
+struct GPIO
+{
+	/**
+	 * Input register.  This is unused for the LEDs.
+	 */
+	uint32_t read;
+	/**
+	 * The output register.  This is a bitmap of GPIO lines to set.
+	 */
+	uint32_t write;
+	/**
+	 * Write enable.  This sets the pins that should be controlled by `write`.
+	 */
+	uint32_t writeEnable;
+
+	/**
+	 * The index of the first GPIO pin connected to a LED.
+	 */
+	static constexpr uint32_t FirstLED = 14;
+	/**
+	 * The index of the last GPIO pin connected to a LED.
+	 */
+	static constexpr uint32_t LastLED = 15;
+	/**
+	 * The number of GPIO pins used for LEDs.
+	 */
+	static constexpr uint32_t LEDCount = LastLED - FirstLED + 1;
+
+	/**
+	 * Helper that defines a set of bits in a GPIO input word used for a
+	 * specific purpose.
+	 */
+	struct InputBits
+	{
+		/**
+		 * The number of bits.
+		 */
+		const uint32_t Count;
+
+		/**
+		 * The offset of the lowest bit in the GPIO input word.
+		 */
+		const uint32_t Shift;
+
+		/**
+		 * The mask used to extract the bits.
+		 */
+		[[nodiscard]] constexpr uint32_t mask() const
+		{
+			return (1 << Count) - 1;
+		}
+
+		/**
+		 * Extract the bits for this range.
+		 */
+		[[nodiscard]] __always_inline uint32_t extract(uint32_t value) const
+		{
+			return (value >> Shift) & mask();
+		}
+	};
+
+	/**
+	 * The buttons zero to three are in the low four bits.
+	 */
+	static constexpr InputBits Buttons = {4, 4};
+
+	/**
+	 * Switches zero to three are in the next four bits.
+	 */
+	static constexpr InputBits Switches = {4, 0};
+
+	/**
+	 * Helper to read all of the bits defined by an `InputBits` instance.
+	 */
+	template<InputBits Bits>
+	__always_inline uint32_t bits() volatile
+	{
+		return Bits.extract(read);
+	}
+
+	/**
+	 * Helper to read a single bit defined by an `InputBits` instance.
+	 */
+	template<InputBits Bits>
+	__always_inline uint32_t bit(uint32_t index) volatile
+	{
+		return (Bits.extract(read) >> index) & 1;
+	}
+
+	/**
+	 * Read the value of all of the buttons.
+	 */
+	uint32_t buttons() volatile
+	{
+		return bits<Buttons>();
+	}
+
+	/**
+	 * Read the value of all of the switches.
+	 */
+	uint32_t switches() volatile
+	{
+		return bits<Switches>();
+	}
+
+	/**
+	 * Read the value of one of the buttons, indicated by index.
+	 */
+	uint32_t button(uint32_t index) volatile
+	{
+		return bit<Buttons>(index);
+	}
+
+	/**
+	 * Read the value of one of the switches, indicated by index.
+	 *
+	 * This should be called `switch`, but that's a keyword in C/C++.
+	 */
+	uint32_t switch_value(uint32_t index) volatile
+	{
+		return bit<Switches>(index);
+	}
+
+	/**
+	 * Helper that maps from an LED index to a bit to set / clear to control
+	 * that LED.  Returns 0 for out-of-bounds LED values and so can be safely
+	 * masked.
+	 */
+	constexpr static uint32_t led_bit(uint32_t index)
+	{
+		if (index >= LEDCount)
+		{
+			return 0;
+		}
+		return 1 << (index + FirstLED);
+	}
+
+	/**
+	 * Enable  all of the LED GPIO pins.
+	 *
+	 * This must be called before `led_on` or `led_off`.
+	 */
+	void enable_all() volatile
+	{
+		uint32_t bitmap = 0;
+		for (uint32_t i = 0; i < LEDCount; i++)
+		{
+			bitmap |= led_bit(i);
+		}
+		writeEnable = bitmap;
+	}
+
+	/**
+	 * Turn on the LED specified by `index`.
+	 */
+	void led_on(uint32_t index) volatile
+	{
+		write = write | led_bit(index);
+	}
+
+	/**
+	 * Turn off the LED specified by `index`.
+	 */
+	void led_off(uint32_t index) volatile
+	{
+		write = write & ~led_bit(index);
+	}
+};

--- a/sdk/include/platform/generic-riscv/platform-uart.hh
+++ b/sdk/include/platform/generic-riscv/platform-uart.hh
@@ -139,7 +139,7 @@ class Uart16550
 		// Disable interrupts
 		intrEnable = 0x00;
 		// Set the divisor latch (we're going to write the divisor) and set the
-		// character width to 8 bits.
+		// character width to 8 bits, one stop bit, no parity.
 		lineControl = 0x83;
 		// Set the divisor
 		data       = divisor & 0xff;
@@ -149,7 +149,12 @@ class Uart16550
 		// Clear the divisor latch
 		lineControl = 0x03;
 		// Enable the FIFO and reset
-		intrIDandFifo = 0x01;
+		// Enabled bits:
+		// 0 - Enable FIFOs
+		// 1 - Clear receive FIFO
+		// 2 - Clear send FIFO
+		// 5 - 64-byte FIFO (if available)
+		intrIDandFifo = 0x1;
 	}
 };
 

--- a/sdk/include/platform/synopsis/platform-uart.hh
+++ b/sdk/include/platform/synopsis/platform-uart.hh
@@ -1,0 +1,80 @@
+#pragma once
+#pragma push_macro("CHERIOT_PLATFORM_CUSTOM_UART")
+#define CHERIOT_PLATFORM_CUSTOM_UART
+#include_next <platform-uart.hh>
+#pragma pop_macro("CHERIOT_PLATFORM_CUSTOM_UART")
+
+/**
+ * The Synopsis extended 16550 UART has two additional registers that are not
+ * part of a standard 16550, one of which allows for fractional multipliers.
+ *
+ * This is always instantiated with 32-bit device registers.  The default baud
+ * rate is set as a template parameter and can be overridden in `init`.
+ */
+template<unsigned DefaultBaudRate = 115'200>
+struct SynopsisExtended16550 : public Uart16550<uint32_t>
+{
+	/**
+	 * Loopback register.  Unused.
+	 */
+	uint32_t loopback;
+
+	/**
+	 * Divisor latch fraction.  When the divisor latch is set (for writing the
+	 * divisor), this is used for the fraction.  RS-232 requires a 3% tolerance
+	 * for the baud rate and an integer divisor over the clock frequency of the
+	 * host may not get within this range.  This register is used to provide a
+	 * 4-bit correction that allows baud rates to stay within the required
+	 * range.
+	 */
+	uint32_t divisorLatchFraction;
+
+	/**
+	 * The divisor is calculated from 16 times the baud rate.  The baud rate is
+	 * in the range of KHz to hundreds of KHz, whereas the clock frequency is
+	 * typically tens to hundreds of MHz.  The divisor must fit in a 16-bit
+	 * integer (written across two 8-bit device registers) and so is scaled to
+	 * ensure that it fits (by a power of two, which makes it trivial to
+	 * reverse the multiplication in the hardware).
+	 */
+	static constexpr uint32_t BaudScaleFactorShift = 4;
+
+	/**
+	 * The value in `divisorLatchFraction` is truncated to this many bits.
+	 */
+	static constexpr uint32_t BaudFractionBits = 4;
+
+	/**
+	 * Initialise the UART.
+	 */
+	void init(unsigned baudRate       = DefaultBaudRate,
+	          unsigned timerFrequency = CPU_TIMER_HZ) volatile
+	{
+		// The multiplier that we will scale the baud rate by.
+		constexpr uint32_t Multiplier = (1 << BaudScaleFactorShift);
+		// The scaled baud rate is used in all of the remaining calculations.
+		// See `BaudScaleFactorShift` for an explanation.
+		uint32_t scaledBaudRate = baudRate * Multiplier;
+		// The divisor to be programmed into the device.
+		uint32_t divisor = timerFrequency / scaledBaudRate;
+		// The remainder of the divisor.
+		uint32_t remainder = timerFrequency % scaledBaudRate;
+		// The remainder is scaled relative to the baud rate to give a
+		// correction factor.
+		remainder = (remainder << (BaudScaleFactorShift + 1)) / scaledBaudRate;
+		// The remainder is rounded up to give the value that can be programmed
+		// into the device register.
+		remainder = (remainder >> 1) + (remainder & 0x1);
+		// Set up the base UART
+		Uart16550<uint32_t>::init(divisor,
+		                          [&]() { divisorLatchFraction = remainder; });
+		// Write a character with the low bit set.  Any value is fine here, but
+		// if we use 0x7 (ASCII bell character) then we should get a beep if it
+		// goes through to the receiver and so can tell whether this worked.
+		blocking_write(0x7);
+	}
+};
+
+#ifndef CHERIOT_PLATFORM_CUSTOM_UART
+using Uart = SynopsisExtended16550<>;
+#endif


### PR DESCRIPTION
This is the CHERIoT SAFE platform in the Arty A7 100 FPGA.

 - Adds a board description file.
 - Separates out the script to generate the hex file from the one to run the simulator.
 - Adds a driver for the GPIO LEDs.  This will change soon because Kunyan is going to change the wiring a bit, but people can play with it now.
 - Improve the generic UART driver slightly.
 - Add a driver for the Synopsis extended version of the 16550 with a divisor that supports higher frequencies.

This is sufficient to build firmware that can be loaded in the Ibex-based CHERIoT-SAFE configuration.  The resulting vhx file can be either added to the bitfile or loaded over the UART if the IROM is configured with:

https://github.com/CHERIoT-Platform/cheriot-safe-uart-boot-rom