### PR TITLE
Add support for importing MMIO capabilities reduced permissions.

### DIFF
--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -103,7 +103,13 @@ namespace
 	{
 		if (gm == nullptr)
 		{
-			Capability heap = const_cast<void *>(MMIO_CAPABILITY(void, heap));
+			Capability heap = const_cast<void *>(
+			  MMIO_CAPABILITY_WITH_PERMISSIONS(void,
+			                                   heap,
+			                                   /*load*/ true,
+			                                   /*store*/ true,
+			                                   /*capabilities*/ true,
+			                                   /*loadMutable*/ true));
 
 			revoker.init();
 			gm = mstate_init(heap, heap.bounds());

--- a/sdk/core/loader/boot.S
+++ b/sdk/core/loader/boot.S
@@ -47,7 +47,10 @@ start:
 	la_abs			a3, __compart_headers_end
 	sub				a3, a3, a1
 	csetaddr		ca1, ca2, a1 // ca2 still has the G root.
-	csetboundsexact	ca1, ca1, a3
+	// FIXME: This should be a set bounds exact, but we currently don't have a
+	// 'pad to capability alignment' command in the linker script and it needs
+	// to span two sections.
+	csetbounds		ca1, ca1, a3
 	// Set up $cra to be the loader's C++ entry point.
 	// We are safe to clobber $cra here because this is the root function on
 	// the call stack.

--- a/tests/mmio-test.cc
+++ b/tests/mmio-test.cc
@@ -1,0 +1,77 @@
+#include "cheri.hh"
+#define TEST_NAME "MMIO"
+#include "tests.hh"
+
+using namespace CHERI;
+
+void check_permissions(Capability<volatile void> mmio, PermissionSet p)
+{
+	PermissionSet mmioPermissions =
+	  Capability{const_cast<void *>(mmio.get())}.permissions();
+	TEST(mmioPermissions == p,
+	     "MMIO regions has permissions {}, expected {}",
+	     mmioPermissions,
+	     p);
+}
+
+void test_mmio()
+{
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, false, false, false),
+	  {Permission::Global});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, false, true, false),
+	  {Permission::Global});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, false, false, true),
+	  {Permission::Global});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, false, true, true),
+	  {Permission::Global});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, true, false, false),
+	  {Permission::Global, Permission::Store});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, true, true, false),
+	  {Permission::Global, Permission::Store, Permission::LoadStoreCapability});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, true, false, true),
+	  {Permission::Global, Permission::Store});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, true, true, true),
+	  {Permission::Global, Permission::Store, Permission::LoadStoreCapability});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, false, false, false),
+	  {Permission::Global, Permission::Load});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, false, true, false),
+	  {Permission::Global, Permission::Load, Permission::LoadStoreCapability});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, false, false, true),
+	  {Permission::Global, Permission::Load});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, false, true, true),
+	  {Permission::Global,
+	   Permission::Load,
+	   Permission::LoadStoreCapability,
+	   Permission::LoadMutable});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, true, false, false),
+	  {Permission::Global, Permission::Load, Permission::Store});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, true, true, false),
+	  {Permission::Global,
+	   Permission::Load,
+	   Permission::Store,
+	   Permission::LoadStoreCapability});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, true, false, true),
+	  {Permission::Global, Permission::Load, Permission::Store});
+	check_permissions(
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, true, true, true),
+	  {Permission::Global,
+	   Permission::Load,
+	   Permission::Store,
+	   Permission::LoadStoreCapability,
+	   Permission::LoadMutable});
+}

--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -92,6 +92,7 @@ void __cheri_compartment("test_runner") run_tests()
 	}
 
 	run_timed("All tests", []() {
+		run_timed("MMIO", test_mmio);
 		run_timed("Static sealing", test_static_sealing);
 		run_timed("Crash recovery", test_crash_recovery);
 		run_timed("Compartment calls", test_compartment_call);

--- a/tests/tests.hh
+++ b/tests/tests.hh
@@ -5,6 +5,7 @@
 #include <debug.hh>
 #include <thread.h>
 
+__cheri_compartment("mmio_test") void test_mmio();
 __cheri_compartment("allocator_test") void test_allocator();
 __cheri_compartment("thread_pool_test") void test_thread_pool();
 __cheri_compartment("futex_test") void test_futex();

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -22,6 +22,8 @@ function test_c(name)
          add_files(name .. "-test.c")
 end
 
+-- Test MMIO access
+test("mmio")
 -- Test the allocator and the revoker.
 test("allocator")
 -- Test the thread pool
@@ -74,6 +76,7 @@ firmware("test-suite")
     -- Helper libraries
     add_deps("freestanding", "string", "crt", "cxxrt", "atomic_fixed")
     -- Tests
+    add_deps("mmio_test")
     add_deps("allocator_test")
     add_deps("thread_pool_test")
     add_deps("futex_test")


### PR DESCRIPTION
This is most useful for read-only access, but the mechanism should be sufficiently general to permit other uses (in particular, once we have CHERI-aware devices, it may be useful to restrict the ability to store capabilities and the ability to load mutable capabilities from devices).