### PR TITLE
Move thread_id_get() into the switcher.

### DIFF
--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -1022,7 +1022,7 @@ class MState
 		// This happens only with the allocator lock held, so we can avoid any
 		// CAS operations.
 		epoch++;
-		*lockWord = (epoch << 16) | thread_id_get_fast();
+		*lockWord = (epoch << 16) | thread_id_get();
 		epoch++;
 		struct Guard
 		{

--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -860,6 +860,11 @@ namespace
 			threadTStack->mshwm  = stack.top();
 			threadTStack->mshwmb = stack.base();
 #endif
+			// Set the thread ID that the switcher will return for this thread.
+			// This is indexed from 1, so 0 can be used to indicate the idle
+			// thread.
+			threadTStack->threadID = i + 1;
+
 			threadTStack->frameoffset = offsetof(TrustedStack, frames[1]);
 			threadTStack->frames[0].calleeExportTable =
 			  build(compartment.exportTable);

--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -437,11 +437,6 @@ int __cheri_compartment("sched") thread_sleep(Timeout *timeout)
 	return 0;
 }
 
-uint16_t __cheri_compartment("sched") thread_id_get(void)
-{
-	return Thread::current_get()->id_get();
-}
-
 int futex_timed_wait(Timeout        *timeout,
                      const uint32_t *address,
                      uint32_t        expected,
@@ -639,11 +634,6 @@ int multiwaiter_wait(Timeout           *timeout,
 		}
 		return 0;
 	});
-}
-
-uint16_t *thread_id_get_pointer(void)
-{
-	return Thread::current_thread_id_pointer();
 }
 
 namespace

--- a/sdk/core/scheduler/thread.h
+++ b/sdk/core/scheduler/thread.h
@@ -109,10 +109,8 @@ namespace
 					  current->priority,
 					  current->OriginalPriority);
 				}
-				currentThreadId = current->threadId;
 				return current->tStackPtr;
 			}
-			currentThreadId = 0;
 			return schedTStack;
 		}
 
@@ -573,18 +571,6 @@ namespace
 		};
 		TrustedStack *tStackPtr;
 
-		/**
-		 * Returns a read-only pointer to a variable containing the current
-		 * thread ID.
-		 */
-		static uint16_t *current_thread_id_pointer()
-		{
-			CHERI::Capability ptr{&currentThreadId};
-			ptr.permissions() &= CHERI::PermissionSet{CHERI::Permission::Global,
-			                                          CHERI::Permission::Load};
-			return ptr;
-		}
-
 		private:
 		/**
 		 * Helper to remove a thread from the priority map and update the
@@ -614,8 +600,6 @@ namespace
 
 		/// the current runnning thread
 		static inline ThreadImpl *current;
-		/// The ID of the current thread.
-		static inline uint16_t currentThreadId;
 		/// NPrios number of lists, each linking the threads of this priority
 		static inline ThreadImpl *priorityList[NPrios];
 		/// A bit field indicating the presence of ready threads. A set bit at

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -777,7 +777,7 @@ exception_entry_asm:
 	// Restore the stack pointer.  All other spilled values are spilled there.
 	clc                csp, TrustedStackFrame_offset_csp(ct1)
 	// Update the current frame offset.
-	csw                t2, TrustedStack_offset_frameoffset(ctp)
+	csh                t2, TrustedStack_offset_frameoffset(ctp)
 	// Do the loads *after* moving the trusted stack pointer.  In theory, the
 	// checks in `check_compartment_stack_integrity` make it impossible for
 	// this to fault, but if we do fault here then we'd end up in an infinite
@@ -943,6 +943,15 @@ __Z28switcher_thread_hazard_slotsv:
 	clc                ca0, TrustedStack_offset_hazardPointers(ca0)
 	cret
 
+	.section .text, "ax", @progbits
+	.p2align 2
+	.type __Z13thread_id_getv,@function
+__Z13thread_id_getv:
+	// Load the trusted stack pointer into a register that we will clobber in
+	// the next instruction when we load the thread ID.
+	cspecialr          ca0, mtdc
+	clh                a0, TrustedStack_offset_threadID(ca0)
+	cret
 
 
 
@@ -978,3 +987,4 @@ export __Z22switcher_recover_stackv
 export __Z25switcher_interrupt_threadPv
 export __Z23switcher_current_threadv
 export __Z28switcher_thread_hazard_slotsv
+export __Z13thread_id_getv

--- a/sdk/core/switcher/trusted-stack-assembly.h
+++ b/sdk/core/switcher/trusted-stack-assembly.h
@@ -46,7 +46,8 @@ EXPORT_ASSEMBLY_OFFSET(TrustedStack,
                        frames,
                        TSTACK_REGFRAME_SZ + TSTACK_HEADER_SZ)
 EXPORT_ASSEMBLY_OFFSET(TrustedStack, frameoffset, TSTACK_REGFRAME_SZ)
-EXPORT_ASSEMBLY_OFFSET(TrustedStack, inForcedUnwind, TSTACK_REGFRAME_SZ + 2)
+EXPORT_ASSEMBLY_OFFSET(TrustedStack, threadID, TSTACK_REGFRAME_SZ + 2)
+EXPORT_ASSEMBLY_OFFSET(TrustedStack, inForcedUnwind, TSTACK_REGFRAME_SZ + 4)
 
 EXPORT_ASSEMBLY_OFFSET(TrustedStackFrame, csp, 0)
 EXPORT_ASSEMBLY_OFFSET(TrustedStackFrame, calleeExportTable, 8)

--- a/sdk/core/switcher/tstack.h
+++ b/sdk/core/switcher/tstack.h
@@ -56,6 +56,10 @@ struct TrustedStackGeneric
 #endif
 	uint16_t frameoffset;
 	/**
+	 * The ID of the current thread.  Never modified during execution.
+	 */
+	uint16_t threadID;
+	/**
 	 * Flag indicating whether this thread is in the process of a forced
 	 * unwind.  If so, this is one, otherwise it is zero.
 	 */
@@ -63,9 +67,9 @@ struct TrustedStackGeneric
 	// Padding up to multiple of 16-bytes.
 	uint8_t padding[
 #ifdef CONFIG_MSHWM
-	  13
+	  11
 #else
-	  5
+	  3
 #endif
 	];
 	/**

--- a/sdk/include/event.h
+++ b/sdk/include/event.h
@@ -55,14 +55,12 @@ int __cheri_libcall eventgroup_create(struct Timeout    *timeout,
  * If `clearOnExit` is true and this returns successfully then the bits in
  * `bitsWanted` will be cleared in the event group before this returns.
  */
-int __cheri_libcall
-eventgroup_wait(Timeout           *timeout,
-                struct EventGroup *group,
-                uint32_t          *outBits,
-                uint32_t           bitsWanted,
-                _Bool              waitForAll,
-                _Bool              clearOnExit,
-                uint16_t threadID  __if_cxx(= thread_id_get_fast()));
+int __cheri_libcall eventgroup_wait(Timeout           *timeout,
+                                    struct EventGroup *group,
+                                    uint32_t          *outBits,
+                                    uint32_t           bitsWanted,
+                                    _Bool              waitForAll,
+                                    _Bool              clearOnExit);
 
 /**
  * Set one or more bits in an event group.  The `bitsToSet` argument contains

--- a/sdk/include/locks.h
+++ b/sdk/include/locks.h
@@ -83,8 +83,7 @@ int __cheri_libcall flaglock_trylock(Timeout *timeout, FlagLockState *lock);
 /**
  * Try to lock a flag lock.  This is the priority-inheriting version.  Some
  * other platforms refer to this as a priority-inheriting mutex or simply a
- * mutex.  The `threadID` argument should be the current thread's ID.  In C++,
- * this should be omitted.
+ * mutex.
  *
  * A higher-priority thread that calls this function while a lock is held will
  * lend its priority to the thread that successfully called this function until
@@ -94,10 +93,8 @@ int __cheri_libcall flaglock_trylock(Timeout *timeout, FlagLockState *lock);
  * Returns 0 on success, -ETIMEDOUT if the timeout expired, or -EINVAL if the
  * arguments are invalid.
  */
-int __cheri_libcall flaglock_priority_inheriting_trylock(
-  Timeout          *timeout,
-  FlagLockState    *lock,
-  uint16_t threadID __if_cxx(= thread_id_get_fast()));
+int __cheri_libcall flaglock_priority_inheriting_trylock(Timeout       *timeout,
+                                                         FlagLockState *lock);
 
 /**
  * Convenience wrapper to acquire a lock with an unlimited timeout.  See
@@ -114,10 +111,10 @@ __always_inline static inline void flaglock_lock(FlagLockState *lock)
  * `flaglock_priority_inheriting_trylock` for more details.
  */
 __always_inline static inline void
-flaglock_priority_inheriting_lock(FlagLockState *lock, uint16_t threadID)
+flaglock_priority_inheriting_lock(FlagLockState *lock)
 {
 	Timeout t{UnlimitedTimeout};
-	flaglock_priority_inheriting_trylock(&t, lock, threadID);
+	flaglock_priority_inheriting_trylock(&t, lock);
 }
 
 /**
@@ -138,10 +135,8 @@ void __cheri_libcall flaglock_unlock(FlagLockState *lock);
  * arguments are invalid.  Can also return -EOVERFLOW if the lock depth would
  * overflow the depth counter.
  */
-int __cheri_libcall
-recursivemutex_trylock(Timeout             *timeout,
-                       RecursiveMutexState *lock,
-                       uint16_t threadID    __if_cxx(= thread_id_get_fast()));
+int __cheri_libcall recursivemutex_trylock(Timeout             *timeout,
+                                           RecursiveMutexState *lock);
 
 /**
  * Unlock a recursive mutex.  Note: This does not check that the current thread

--- a/sdk/include/locks.hh
+++ b/sdk/include/locks.hh
@@ -50,8 +50,7 @@ class FlagLockGeneric
 	{
 		if constexpr (IsPriorityInherited)
 		{
-			return flaglock_priority_inheriting_trylock(
-			         timeout, &state, thread_id_get_fast()) == 0;
+			return flaglock_priority_inheriting_trylock(timeout, &state) == 0;
 		}
 		else
 		{

--- a/sdk/include/thread.h
+++ b/sdk/include/thread.h
@@ -40,16 +40,10 @@ typedef struct
  * Return the thread ID of the current running thread.
  * This is mostly useful where one compartment can run under different threads
  * and it matters which thread entered this compartment.
+ *
+ * This is implemented in the switcher.
  */
-[[cheri::interrupt_state(disabled)]] uint16_t __cheri_compartment("sched")
-  thread_id_get(void);
-
-/**
- * Returns a cacheable (read-only) pointer to a global owned by the scheduler
- * that contains the current thread ID.  Reading this pointer will return the
- * thread ID of the currently running thread.
- */
-__cheri_compartment("sched") uint16_t *thread_id_get_pointer(void);
+uint16_t __cheri_libcall thread_id_get(void);
 
 /**
  * Returns the number of cycles accounted to the idle thread.
@@ -79,19 +73,3 @@ __cheri_compartment("sched") uint64_t thread_elapsed_cycles_current(void);
 __cheri_compartment("sched") uint16_t thread_count();
 
 __END_DECLS
-#ifdef __cplusplus
-/**
- * Helper function that returns the current thread ID.  This will do a
- * cross-compartment call the first time it is called but not on any
- * subsequent calls.
- */
-inline uint16_t thread_id_get_fast()
-{
-	static uint16_t *ptr;
-	if (!ptr)
-	{
-		ptr = thread_id_get_pointer();
-	}
-	return *ptr;
-}
-#endif

--- a/sdk/lib/event_group/event_group.cc
+++ b/sdk/lib/event_group/event_group.cc
@@ -59,8 +59,7 @@ int eventgroup_wait(Timeout    *timeout,
                     uint32_t   *outBits,
                     uint32_t    bitsWanted,
                     bool        waitForAll,
-                    bool        clearOnExit,
-                    uint16_t    threadID)
+                    bool        clearOnExit)
 {
 	// Bits wanted can be only a 24-bit value.
 	if (bitsWanted & 0xff000000)
@@ -72,7 +71,7 @@ int eventgroup_wait(Timeout    *timeout,
 		return (waitForAll ? ((bitsWanted & bits) == bitsWanted)
 		                   : ((bitsWanted & bits) != 0));
 	};
-	auto    &waiter = group->waiters[threadID];
+	auto    &waiter = group->waiters[thread_id_get()];
 	uint32_t bitsSeen;
 	// Set up our state for the waiter with the lock held.
 	if (LockGuard g{group->lock, timeout})

--- a/sdk/lib/locks/locks.cc
+++ b/sdk/lib/locks/locks.cc
@@ -185,10 +185,10 @@ int __cheri_libcall flaglock_trylock(Timeout *t, FlagLockState *lock)
 	return static_cast<InternalFlagLock *>(lock)->try_lock(t, 0, false);
 }
 int __cheri_libcall flaglock_priority_inheriting_trylock(Timeout       *t,
-                                                         FlagLockState *lock,
-                                                         uint16_t threadID)
+                                                         FlagLockState *lock)
 {
-	return static_cast<InternalFlagLock *>(lock)->try_lock(t, threadID, true);
+	return static_cast<InternalFlagLock *>(lock)->try_lock(
+	  t, thread_id_get(), true);
 }
 void __cheri_libcall flaglock_unlock(FlagLockState *lock)
 {
@@ -204,10 +204,9 @@ void __cheri_libcall ticketlock_unlock(TicketLockState *lock)
 	static_cast<InternalTicketLock *>(lock)->unlock();
 }
 
-int recursivemutex_trylock(Timeout             *timeout,
-                           RecursiveMutexState *mutex,
-                           uint16_t             threadID)
+int recursivemutex_trylock(Timeout *timeout, RecursiveMutexState *mutex)
 {
+	auto              threadID = thread_id_get();
 	InternalFlagLock *internalLock =
 	  static_cast<InternalFlagLock *>(&mutex->lock);
 	if (internalLock->try_lock(timeout, threadID, true) == 0)

--- a/tests/eventgroup-test.cc
+++ b/tests/eventgroup-test.cc
@@ -15,7 +15,7 @@ namespace
 	void                  barrier()
 	{
 		int c = --counter;
-		debug_log("Thread {} waiting for barrier {}", thread_id_get_fast(), c);
+		debug_log("Thread {} waiting for barrier {}", thread_id_get(), c);
 		while (counter > 0)
 		{
 			counter.wait(c);

--- a/tests/futex-test.cc
+++ b/tests/futex-test.cc
@@ -114,7 +114,7 @@ void test_futex()
 	futex = 0;
 	static cheriot::atomic<int> state;
 	auto                        priorityBug = []() {
-        if (thread_id_get_fast() == 2)
+        if (thread_id_get() == 2)
         {
             debug_log("Medium-priority task starting");
             // We are the high priority thread, wait for the futex to be
@@ -132,7 +132,7 @@ void test_futex()
         else
         {
             debug_log("Low-priority task starting");
-            futex = thread_id_get_fast();
+            futex = thread_id_get();
             state = 1;
             debug_log("Low-priority thread acquired futex, yielding");
             // Now the high priority thread should run.

--- a/tests/queue-test.cc
+++ b/tests/queue-test.cc
@@ -19,7 +19,7 @@ extern "C" ErrorRecoveryBehaviour
 compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval)
 {
 	debug_log("Thread {} error handler invoked with mcause {}.  PCC: {}",
-	          thread_id_get_fast(),
+	          thread_id_get(),
 	          mcause,
 	          frame->pcc);
 	return ErrorRecoveryBehaviour::ForceUnwind;

--- a/tests/thread_pool-test.cc
+++ b/tests/thread_pool-test.cc
@@ -23,19 +23,19 @@ extern "C" ErrorRecoveryBehaviour
 compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval)
 {
 	debug_log("Thread {} error handler invoked with mcause {}.  PCC: {}",
-	          thread_id_get_fast(),
+	          thread_id_get(),
 	          mcause,
 	          frame->pcc);
 	if (mcause != 25)
 	{
 		return ErrorRecoveryBehaviour::ForceUnwind;
 	}
-	if (thread_id_get_fast() != interruptThreadNumber)
+	if (thread_id_get() != interruptThreadNumber)
 	{
 		debug_log(
 		  "Explicit thread interrupt delivered on the wrong thread (thread {}, "
 		  "expected {})",
-		  thread_id_get_fast(),
+		  thread_id_get(),
 		  interruptThreadNumber.load());
 		return ErrorRecoveryBehaviour::ForceUnwind;
 	}
@@ -52,9 +52,6 @@ void test_thread_pool()
 	TEST(thread_id_get() == 1,
 	     "Thread id of main thread should be 1, is {}",
 	     thread_id_get());
-	TEST(thread_id_get_fast() == 1,
-	     "Thread id of main thread should be 1, is {}",
-	     thread_id_get_fast());
 	// Run a simple stateless callback that increments a global in the thread
 	// pool.  This demonstrates that we can correctly capture a stateless
 	// function and pass it to the worker thread.
@@ -89,7 +86,7 @@ void test_thread_pool()
 	free(heapInt);
 
 	async([]() {
-		auto fast = thread_id_get_fast();
+		auto fast = thread_id_get();
 		auto slow = thread_id_get();
 		TEST(fast == slow,
 		     "Thread ID is different in fast ({}) and slow ({}) accessors",
@@ -113,7 +110,7 @@ void test_thread_pool()
 	static void *asyncThread;
 	static bool  interrupted;
 	async([=]() mutable {
-		interruptThreadNumber = thread_id_get_fast();
+		interruptThreadNumber = thread_id_get();
 		asyncThread           = switcher_current_thread();
 		while (!interruptStarted)
 		{


### PR DESCRIPTION
This is reading a single value per thread, which never changes, and so adds only three instructions (including cret) to the switcher.  We previously had two ways of getting the thread ID:

 - thread_id_get() returned the ID, but required a full compartment switch into the scheduler.
 - thread_id_get_pointer() retrieved a cacheable pointer that could be dereferenced to give the current thread ID.

The latter form was fast, but could not be used in shared libraries because it required capturing the returned pointer.

This simplifies the locks APIs and means that the message-queue compartment can be entirely stateless (no mutable globals) and so a compromise cannot persist.