### PR TITLE
Lock fixes

### DIFF
--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -117,7 +117,7 @@ namespace
 			freeStart.wait(0);
 			// One extra sleep to make sure that we're really in the blocking
 			// sleep.
-			Timeout t{1};
+			Timeout t{2};
 			thread_sleep(&t);
 			debug_log(
 			  "Deallocation thread resuming, freeing pool of allocations");

--- a/tests/futex-test.cc
+++ b/tests/futex-test.cc
@@ -112,6 +112,7 @@ void test_futex()
 
 	debug_log("Starting priority inheritance test");
 	futex = 0;
+
 	static cheriot::atomic<int> state;
 	auto                        priorityBug = []() {
         if (thread_id_get() == 2)
@@ -171,6 +172,17 @@ void test_futex()
 	ret         = futex_timed_wait(&t, &futex, futex, FutexPriorityInheritance);
 	TEST(ret == -EINVAL,
 	     "PI futex with an invalid thread ID returned {}, should be {}",
+	     ret,
+	     -EINVAL);
+
+	futex = 0;
+	debug_log(
+	  "Testing priority inheriting futex_timed_wait with zero thread ID");
+	// zero is not a valid thread ID for priority inheriting futex. Previously
+	// this caused a crash due to OOB access but better to return -EINVAL.
+	ret = futex_timed_wait(&t, &futex, 0, FutexPriorityInheritance);
+	TEST(ret == -EINVAL,
+	     "PI futex with a zero thread ID returned {}, should be {}",
 	     ret,
 	     -EINVAL);
 }

--- a/tests/locks-test.cc
+++ b/tests/locks-test.cc
@@ -102,7 +102,7 @@ namespace
 			done = true;
 		});
 		// Give other thread a chance to run
-		sleep(1);
+		sleep(2);
 		// Check that it hasn't acquired the lock yet as we still have it
 		TEST(
 		  done == false,
@@ -110,13 +110,13 @@ namespace
 		// Unlock once, should still not release the lock
 		debug_log("Releasing recurisve mutex once");
 		recursivemutex_unlock(&recursiveMutex);
-		sleep(1);
+		sleep(2);
 		TEST(
 		  done == false,
 		  "Recursive mutex trylock succeeded on mutex owned by another thread");
 		debug_log("Releasing recurisve mutex again");
 		recursivemutex_unlock(&recursiveMutex);
-		sleep(1);
+		sleep(2);
 		TEST(done == true,
 		     "Recursive mutex acquire failed from other thread after mutex was "
 		     "unlocked");


### PR DESCRIPTION
Various fixes related to logging in three separate commits:

1) Fix OOB access in scheduler, add a test and some logging.
2) Fix unnecessary wait failures and spurious notifies in `InternalFlagLock::try_lock`
3) Actually run the recursive mutex test and make it pass.