### PR TITLE
Fixes to C headers and debug output.

### DIFF
--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include <cdefs.h>
+#include <stdbool.h>
 
 /**
  * Helper macro, should not be used directly.

--- a/sdk/include/debug.hh
+++ b/sdk/include/debug.hh
@@ -220,6 +220,22 @@ namespace
 		}
 
 		/**
+		 * Append a 16-bit unsigned integer to the buffer as hex.
+		 */
+		__always_inline void append(uint16_t s)
+		{
+			append(static_cast<uint32_t>(s));
+		}
+
+		/**
+		 * Append an 8-bit unsigned integer to the buffer as hex.
+		 */
+		__always_inline void append(uint8_t s)
+		{
+			append(static_cast<uint32_t>(s));
+		}
+
+		/**
 		 * Append an enumerated type value.
 		 */
 		template<typename T>

--- a/sdk/include/stdatomic.h
+++ b/sdk/include/stdatomic.h
@@ -33,31 +33,33 @@ typedef _Atomic(_Bool) atomic_flag;
 // Clang thinks that all atomics are too big, so ignore it.
 __clang_ignored_warning_push("-Watomic-alignment")
 
-__always_inline _Bool
-atomic_flag_test_and_set_explicit(volatile atomic_flag *obj, enum memory_order order)
+  __always_inline static inline _Bool
+  atomic_flag_test_and_set_explicit(volatile atomic_flag *obj,
+                                    enum memory_order     order)
 {
 	return __c11_atomic_exchange(obj, 1, order);
 }
 
-__always_inline _Bool atomic_flag_test_and_set(volatile atomic_flag *obj)
+__always_inline static inline _Bool
+atomic_flag_test_and_set(volatile atomic_flag *obj)
 {
 	return atomic_flag_test_and_set_explicit(obj, memory_order_seq_cst);
 }
 
-__always_inline _Bool
+__always_inline static inline _Bool
 atomic_flag_test_and_clear_explicit(volatile atomic_flag *obj,
-                                    enum memory_order          order)
+                                    enum memory_order     order)
 {
 	return __c11_atomic_exchange(obj, 0, order);
 }
 
-__always_inline _Bool atomic_flag_test_and_clear(volatile atomic_flag *obj)
+__always_inline static inline _Bool
+atomic_flag_test_and_clear(volatile atomic_flag *obj)
 {
 	return atomic_flag_test_and_clear_explicit(obj, memory_order_seq_cst);
 }
 
 __clang_ignored_warning_pop()
-
 
 // The functions in the following block are mapped directly to builtins.
 #	define atomic_init(obj, value) __c11_atomic_init(obj, value)
@@ -150,4 +152,3 @@ typedef _Atomic(intptr_t)           atomic_intptr_t;
 typedef _Atomic(uintptr_t)          atomic_uintptr_t;
 typedef _Atomic(size_t)             atomic_size_t;
 typedef _Atomic(ptrdiff_t)          atomic_ptrdiff_t;
-

--- a/sdk/include/string.h
+++ b/sdk/include/string.h
@@ -15,3 +15,9 @@ int __cheri_libcall    strncmp(const char *s1, const char *s2, size_t n);
 char *__cheri_libcall  strncpy(char *dest, const char *src, size_t n);
 int __cheri_libcall    strcmp(const char *s1, const char *s2);
 char *__cheri_libcall  strstr(const char *haystack, const char *needle);
+char *__cheri_libcall  strchr(const char *s, int c);
+
+__always_inline static inline char *strcpy(char *dst, const char *src)
+{
+	return strncpy(dst, src, SIZE_MAX);
+}

--- a/sdk/lib/string/strchr.c
+++ b/sdk/lib/string/strchr.c
@@ -1,0 +1,14 @@
+#include <string.h>
+
+char *strchr(const char *s, int intChar)
+{
+	char c = (char)intChar;
+	while (*s != c)
+	{
+		if (!*s++)
+		{
+			return NULL;
+		}
+	}
+	return (char *)s;
+}

--- a/sdk/lib/string/xmake.lua
+++ b/sdk/lib/string/xmake.lua
@@ -1,2 +1,2 @@
 library("string")
-  add_files("strcmp.c", "strlen.c", "strncpy.c", "strstr.c")
+  add_files("strcmp.c", "strlen.c", "strncpy.c", "strstr.c", "strchr.c")


### PR DESCRIPTION
Most of these are fixes for either:

 - Macros that we don't test using don't actually work in C code.
 - C headers contain things that don't work if you include them in more than one compilation unit.

At the same time, add explicit overloads for printing uint16_t / uint32_t.  Without this, integer promotion promotes them to int and we print them as signed (decimal) numbers, not as hex.