### PR TITLE
Small fixes to the FreeRTOS compat layer:

### DIFF
--- a/sdk/include/FreeRTOS-Compat/event_groups.h
+++ b/sdk/include/FreeRTOS-Compat/event_groups.h
@@ -2,6 +2,7 @@
 #include "FreeRTOS.h"
 #include <event.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 /**
  * Type for bits in an event group.
@@ -61,8 +62,8 @@ static inline EventBits_t xEventGroupWaitBits(EventGroupHandle_t xEventGroup,
 	                                         xEventGroup,
 	                                         &ret,
 	                                         uxBitsToWaitFor,
-	                                         xClearOnExit,
-	                                         xWaitForAllBits);
+	                                         xWaitForAllBits,
+	                                         xClearOnExit);
 	return ret;
 }
 
@@ -71,5 +72,5 @@ static inline EventBits_t xEventGroupWaitBits(EventGroupHandle_t xEventGroup,
  */
 static inline void vEventGroupDelete(EventGroupHandle_t xEventGroup)
 {
-	free(xEventGroup);
+	eventgroup_destroy(MALLOC_CAPABILITY, xEventGroup);
 }

--- a/sdk/include/FreeRTOS-Compat/queue.h
+++ b/sdk/include/FreeRTOS-Compat/queue.h
@@ -2,8 +2,8 @@
 #include "FreeRTOS.h"
 #include <queue.h>
 
-#define errQUEUE_EMPTY ((BaseType_t)0)
-#define errQUEUE_FULL ((BaseType_t)0)
+#define errQUEUE_EMPTY pdFALSE
+#define errQUEUE_FULL pdFALSE
 
 /**
  * Queue handle.  This is used to reference queues in the API functions.

--- a/sdk/include/event.h
+++ b/sdk/include/event.h
@@ -101,3 +101,10 @@ int __cheri_libcall eventgroup_clear(Timeout           *timeout,
  * cleared in between this call reading from the event group and returning.
  */
 int __cheri_libcall eventgroup_get(struct EventGroup *group, uint32_t *outBits);
+
+/**
+ * Destroy an event group.  This forces all waiters to wake and frees the
+ * underlying memory.
+ */
+int __cheri_libcall eventgroup_destroy(struct SObjStruct *heapCapability,
+                                       struct EventGroup *group);


### PR DESCRIPTION
 - The order of clear-on-exit and wait-for-all flags was incorrect in the event-wait function.
 - Make sure that we can kick all waiters out of a sleep state when we delete an event group.
 - Make the queue error values match the macros that calling code compares them against.