### PR TITLE
Do not zero-pad in strncpy.

### DIFF
--- a/sdk/include/string.h
+++ b/sdk/include/string.h
@@ -16,8 +16,10 @@ char *__cheri_libcall  strncpy(char *dest, const char *src, size_t n);
 int __cheri_libcall    strcmp(const char *s1, const char *s2);
 char *__cheri_libcall  strstr(const char *haystack, const char *needle);
 char *__cheri_libcall  strchr(const char *s, int c);
+size_t __cheri_libcall strlcpy(char *dest, const char *src, size_t n);
+
 
 __always_inline static inline char *strcpy(char *dst, const char *src)
 {
-	return strncpy(dst, src, SIZE_MAX);
+	return dst + strlcpy(dst, src, SIZE_MAX);
 }

--- a/sdk/lib/string/strlcpy.c
+++ b/sdk/lib/string/strlcpy.c
@@ -1,0 +1,19 @@
+#include <string.h>
+
+size_t strlcpy(char *dest, const char *src, size_t n)
+{
+	size_t copySize = n == 0 ? 0 : n - 1;
+	size_t i;
+
+	// Copy up to n - 1 characters from the source string to the destination
+	for (i = 0; i < copySize && src[i] != '\0'; i++)
+	{
+		dest[i] = src[i];
+	}
+	// If the size is not 0, add a null terminator to the end of the string
+	if (n != 0)
+	{
+		dest[i] = '\0';
+	}
+	return i;
+}

--- a/sdk/lib/string/xmake.lua
+++ b/sdk/lib/string/xmake.lua
@@ -1,3 +1,3 @@
 library("string")
   set_default(false)
-  add_files("strcmp.c", "strlen.c", "strncpy.c", "strstr.c", "strchr.c")
+  add_files("strcmp.c", "strlen.c", "strncpy.c", "strstr.c", "strchr.c", "strlcpy.c")


### PR DESCRIPTION
We have a strcpy implementation that wraps strncpy, so we end up trying to pad 4 GiBs of zeroes.