### PR TITLE
Fix defining static sealing values with structures.

### DIFF
--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -187,8 +187,7 @@
 	  name = /* NOLINT(bugprone-macro-parentheses) */                          \
 	  {(uint32_t)&__sealing_key_##compartment##_##keyName,                     \
 	   0,                                                                      \
-	   initialiser,                                                            \
-	   ##__VA_ARGS__}
+	   {initialiser, ##__VA_ARGS__}}
 
 /**
  * Helper macro that declares and defines a sealed value.
@@ -205,7 +204,8 @@
 	  compartment,                                                             \
 	  keyName,                                                                 \
 	  name,                                                                    \
-	  initialiser); /* NOLINT(bugprone-macro-parentheses) */
+	  initialiser,                                                             \
+	  ##__VA_ARGS__); /* NOLINT(bugprone-macro-parentheses) */
 
 /**
  * Returns a sealed capability to the named object created with

--- a/tests/static_sealing-test.cc
+++ b/tests/static_sealing-test.cc
@@ -13,7 +13,7 @@ DECLARE_AND_DEFINE_STATIC_SEALED_VALUE(TestType,
                                        static_sealing_inner,
                                        SealingType,
                                        test,
-                                       {42});
+                                       42);
 
 void test_static_sealing()
 {


### PR DESCRIPTION
The test and malloc-capability macros were inconsistent in how they expected these to be use:

 - The test wanted to pass all arguments in braces.
 - The malloc macro wanted to pass them as separate arguments.

The implementation expected the former, but broke when you actually tried to pass multiple values.  This happened to work with malloc capabilities because we were zero-initialising the subsequent fields and so ignoring the explicit zeroes was fine.

This is now fixed to use a variadic macro (hopefully) correctly.