### PR TITLE
Add a concept for a platform entropy source and a weak implementation.

### DIFF
--- a/sdk/include/platform/arty-a7/platform-entropy.hh
+++ b/sdk/include/platform/arty-a7/platform-entropy.hh
@@ -1,0 +1,67 @@
+#pragma once
+#include <compartment-macros.h>
+#include <ds/xoroshiro.h>
+#include <interrupt.h>
+#include <platform/concepts/entropy.h>
+#include <riscvreg.h>
+
+DECLARE_AND_DEFINE_INTERRUPT_CAPABILITY(RevokerInterruptEntropy,
+                                        InterruptName::EthernetReceiveInterrupt,
+                                        true,
+                                        false)
+
+/**
+ * A simple entropy source.  This wraps a few weak entropy sources to seed a
+ * PRNG.  It is absolutely not secure and should not be used for anything that
+ * depends on cryptographically secure random numbers!  Unfortunately, there is
+ * nothing on the Arty A7 instantiation of CHERIoT SAFE that can be used as a
+ * secure entropy source.
+ */
+class EntropySource
+{
+	ds::xoroshiro::P128R64 prng;
+	const uint32_t        *ethernetInterruptCount;
+
+	public:
+	using ValueType = uint64_t;
+
+	/// Definitely not secure!
+	static constexpr bool IsSecure = false;
+
+	/// Constructor, tries to generate an independent sequence of random numbers
+	EntropySource()
+	{
+		ethernetInterruptCount =
+		  interrupt_futex_get(STATIC_SEALED_VALUE(RevokerInterruptEntropy));
+		reseed();
+	}
+
+	/// Reseed the PRNG
+	void reseed()
+	{
+		// Start from a not very random seed
+		uint64_t seed = rdcycle64();
+		prng.set_state(seed, seed >> 24);
+		uint32_t interrupts = *ethernetInterruptCount;
+		// Permute it with another not-very-random number
+		for (uint32_t i = 0; i < ((interrupts & 0xff00) >> 8); i++)
+		{
+			prng.long_jump();
+		}
+		for (uint32_t i = 0; i < (interrupts & 0xff); i++)
+		{
+			prng.jump();
+		}
+		// At this point, our random number is in a fairly predictable state,
+		// but with a fairly low probability of being the same predictable
+		// state as before.
+	}
+
+	ValueType operator()()
+	{
+		return prng();
+	}
+};
+
+static_assert(IsEntropySource<EntropySource>,
+              "EntropySource must be an entropy source");

--- a/sdk/include/platform/concepts/entropy.h
+++ b/sdk/include/platform/concepts/entropy.h
@@ -1,0 +1,36 @@
+#pragma once
+#include <array>
+#include <concepts>
+#include <cstdint>
+
+/**
+ * Concept for an Ethernet adaptor.
+ */
+template<typename T>
+concept IsEntropySource = requires(T source)
+{
+	/**
+	 * Must export a flag indicating whether this is a cryptographically
+	 * secure random number.
+	 */
+	{
+		T::IsSecure
+		} -> std::convertible_to<const bool>;
+
+	/**
+	 * Must return a random number.  All bits of the value type are assumed to
+	 * be random, this should use a narrower type if it guarantees less
+	 * entropy.
+	 */
+	{
+		source()
+		} -> std::same_as<typename T::ValueType>;
+
+	/**
+	 * Must provide a method that reseeds the entropy source.  If this is a
+	 * hardware whitening engine that is continuously fed with entropy, this
+	 * may be an empty function.  There are no constraints on the return type
+	 * of this.
+	 */
+	{source.reseed()};
+};


### PR DESCRIPTION
The Ibex / Arty A7 uses the cycle count and the number of Ethernet interrupts to seed.  The first of these starts counting when the first-stage (ROM) loader runs and so depends on the speed at which we load the firmware over the UART, the second after the scheduler starts and depends on external network traffic.  These are not even slightly cryptographically secure, but they do provide enough entropy that we get different values from the PRNG across different runs and so can pretend for the purpose of a prototyping platform.