### PR TITLE
A few small fixes:

### DIFF
--- a/sdk/include/FreeRTOS-Compat/task.h
+++ b/sdk/include/FreeRTOS-Compat/task.h
@@ -75,6 +75,8 @@ static inline TaskHandle_t xTaskGetCurrentTaskHandle(void)
 	return thread_id_get();
 }
 
+__BEGIN_DECLS
+
 /**
  * Lock used to simulate disabling interrupts in `taskENTER_CRITICAL` and
  * `taskEXIT_CRITICAL`.  Code using these APIs must provide a definition to
@@ -88,6 +90,8 @@ extern struct RecursiveMutexState __CriticalSectionFlagLock;
  * accompany this declaration.
  */
 extern struct RecursiveMutexState __SuspendFlagLock;
+
+__END_DECLS
 
 /**
  * Critical section.  This acquires a recursive mutex.  In FreeRTOS, this

--- a/sdk/include/stdio.h
+++ b/sdk/include/stdio.h
@@ -18,6 +18,7 @@ int __cheri_libcall printf(const char *fmt, ...);
 	printf(__XSTRING(__CHERI_COMPARTMENT__) ": " fmt, ##__VA_ARGS__)
 
 int __cheri_libcall snprintf(char *str, size_t size, const char *format, ...);
+int __cheri_libcall vsnprintf(char *str, size_t size, const char *format, va_list ap); 
 __END_DECLS
 
 #endif /* !__STDIO_H__ */

--- a/sdk/include/string.h
+++ b/sdk/include/string.h
@@ -18,8 +18,16 @@ char *__cheri_libcall  strstr(const char *haystack, const char *needle);
 char *__cheri_libcall  strchr(const char *s, int c);
 size_t __cheri_libcall strlcpy(char *dest, const char *src, size_t n);
 
+/**
+ * Explicit bzero is a memset variant that the compiler is not permitted to
+ * remove.  Our implementation simply wraps memset and is safe from removal
+ * because it is provided by a different shared library.
+ */
+void __cheri_libcall explicit_bzero(void *s, size_t n);
 
 __always_inline static inline char *strcpy(char *dst, const char *src)
 {
 	return dst + strlcpy(dst, src, SIZE_MAX);
 }
+
+

--- a/sdk/lib/freestanding/memset.c
+++ b/sdk/lib/freestanding/memset.c
@@ -88,3 +88,9 @@ void *__cheri_libcall memset(void *dst0, int c0, size_t length)
 		} while (--t != 0);
 	return (dst0);
 }
+
+void __cheri_libcall explicit_bzero(void *s, size_t n)
+{
+	memset(s, 0, n);
+}
+

--- a/sdk/lib/stdio/printf.c
+++ b/sdk/lib/stdio/printf.c
@@ -498,7 +498,7 @@ static int kvprintf(char const *fmt,
 /*
  * Scaled down version of vsnprintf(3).
  */
-static int vsnprintf(char *str, size_t size, const char *format, va_list ap)
+int __cheri_libcall vsnprintf(char *str, size_t size, const char *format, va_list ap)
 {
 	struct snprintf_arg info;
 	int                 retval;


### PR DESCRIPTION
 - Add a missing extern "C"
 - Expose vsnprintf (we have it, it's useful, let's expose it).
 - Add explicit_bzero (it's just a different name for memset for us, since our memsset is in a shared library, but the compiler treats it differently).