### PR TITLE
Fix erroneous check for empty trusted stack.

### DIFF
--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -769,7 +769,7 @@ exception_entry_asm:
 	clear_hazard_slots ctp, ct2
 	// make sure there is a frame left in the trusted stack
 	clhu               t2, TrustedStack_offset_frameoffset(ctp)
-	li                 tp, TrustedStackFrame_size
+	li                 tp, TrustedStack_offset_frames
 	bgeu               tp, t2, .Lset_mcause_and_exit_thread
 	cspecialr          ctp, mtdc
 	addi               t2, t2, -TrustedStackFrame_size


### PR DESCRIPTION
The check in `pop_trusted_stack_frame` needs to compare the trusted stack offset against the offset of frames field in `TrustedStack` to check whether we have reached the top of the trusted stack  (which grows upwards). This is the same as the check in `handle_error`.

Spotted because tests were raising several exceptions before eventually exiting due to failure to spot empty trusted stack.