### PR TITLE
Enable linker dead-code elimination.

### DIFF
--- a/sdk/compartment.ldscript
+++ b/sdk/compartment.ldscript
@@ -71,10 +71,3 @@ SECTIONS
 		*(.comment);
 	}
 }
-# Export the exported function table.
-VERSION {
-	VERSION_1 {
-		global: __export_*;
-		local: *;
-	};
-};

--- a/sdk/include/compartment-macros-asm.S
+++ b/sdk/include/compartment-macros-asm.S
@@ -7,7 +7,7 @@
 .macro CHERIOT_EXPORT_FUNCTION_INTERNAL prefix, function_name, \
   minimum_stack, flags
 
-	.section .compartment_exports,"aw",@progbits
+	.section .compartment_exports,"awR",@progbits
 	.type    \prefix\()_\function_name\(),@object
 	.global  \prefix\()_\function_name\()
     .p2align 2

--- a/sdk/library.ldscript
+++ b/sdk/library.ldscript
@@ -33,7 +33,7 @@ SECTIONS
 	.rodata :
 	{
 		*(.rodata .rodata.*);
-		*(.data.rel.ro);
+		*(.data.rel.ro .data.rel.ro.*);
 	}
 	# BSS remains in a separate section so that we can find it later.
 	.bss :
@@ -55,10 +55,3 @@ SECTIONS
 		*(.sdata .sdata.*);
 	}
 }
-# Export the exported function table.
-VERSION {
-	VERSION_1 {
-		global: __export_*;
-		local: *;
-	};
-};

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -75,6 +75,8 @@ toolchain("cheriot-clang")
 			"-nostdinc",
 			"-Oz",
 			"-g",
+			"-ffunction-sections",
+			"-fdata-sections",
 			"-fomit-frame-pointer",
 			"-fno-builtin",
 			"-fno-exceptions",
@@ -129,7 +131,7 @@ rule("cheriot.component")
 		-- Link using the compartment's linker script.
 		batchcmds:show_progress(opt.progress, "linking " .. target:get("cheriot.type") .. ' ' .. target:filename())
 		batchcmds:mkdir(target:targetdir())
-		batchcmds:vrunv(target:tool("ld"), table.join({"--script=" .. linkerscript, "--compartment", "--relax", "-o", target:targetfile()}, target:objectfiles()), opt)
+		batchcmds:vrunv(target:tool("ld"), table.join({"--script=" .. linkerscript, "--compartment", "--gc-sections", "--relax", "-o", target:targetfile()}, target:objectfiles()), opt)
 		-- This depends on all of the object files and the linker script.
 		batchcmds:add_depfiles(linkerscript)
 		batchcmds:add_depfiles(target:objectfiles())


### PR DESCRIPTION
This is essential for BearSSL, which wants to compile everything but then throw away all of the things that are not referenced by your specific use case.  It's nice to have for everything else.  It reduces the size of the FreeRTOS network stack by around 7.5%.

Savings in the test suite are very small (around 1%) and mostly come from some functions in headers that should be `inline` and aren't.