### PR TITLE
Implement lock destruction feature + cleanup in locking-related code

### DIFF
--- a/sdk/include/futex.h
+++ b/sdk/include/futex.h
@@ -31,7 +31,8 @@ enum [[clang::flag_enum]] FutexWaitFlags{
  * call.
  *
  * This returns:
- *  - 0 on success.
+ *  - 0 on success: either `*address` and `expected` differ or a wake is
+ *    received.
  *  - `-EINVAL` if the arguments are invalid.
  *  - `-ETIMEOUT` if the timeout expires.
  */

--- a/sdk/include/locks.hh
+++ b/sdk/include/locks.hh
@@ -84,6 +84,15 @@ class FlagLockGeneric
 	{
 		flaglock_unlock(&state);
 	}
+
+	/**
+	 * Set the lock in destruction mode. See the documentation of
+	 * `flaglock_upgrade_for_destruction` for more information.
+	 */
+	__always_inline void upgrade_for_destruction()
+	{
+		flaglock_upgrade_for_destruction(&state);
+	}
 };
 
 /**

--- a/sdk/include/locks.hh
+++ b/sdk/include/locks.hh
@@ -21,10 +21,9 @@ __clang_ignored_warning_push("-Watomic-alignment");
 
 /**
  * A simple flag log, wrapping an atomic word used with the `futex` calls.
- * Threads blocked on this will be woken in priority order but this does not
- * propagate priority and so can lead to priority inversion if a low-priority
- * thread is attempting to acquire a flag lock to perform an operation on
- * behalf of a high priority thread.
+ * Threads blocked on this will be woken in priority order. If
+ * `IsPriorityInherited` is set, priority is inherited by waiters to avoid
+ * priority inversion issues.
  *
  * The lock word that this wraps is directly accessibly by any malicious
  * compartment that has a reference to this thread.  If this is a security

--- a/sdk/lib/locks/locks.cc
+++ b/sdk/lib/locks/locks.cc
@@ -16,21 +16,8 @@ namespace
 	  ;
 	using Debug = ConditionalDebug<DebugLocks, "Locking">;
 	/**
-	 * A simple flag log, wrapping an atomic word used with the `futex` calls.
-	 * Threads blocked on this will be woken in priority order but this does not
-	 * propagate priority and so can lead to priority inversion if a
-	 * low-priority thread is attempting to acquire a flag lock to perform an
-	 * operation on behalf of a high priority thread.
-	 *
-	 * The lock word that this wraps is directly accessibly by any malicious
-	 * compartment that has a reference to this thread.  If this is a security
-	 * concern then you may have other problems: a malicious compartment with
-	 * access to a mutex's interface (irrespective of the underlying
-	 * implementation) can cause deadlock by spuriously acquiring a lock or
-	 * cause data corruption via races by spuriously releasing it.  Anything
-	 * that requires mutual exclusion in the presence of mutual distrust should
-	 * consider an using a lock manager compartment with an API that returns a
-	 * single-use capability to unlock on any lock call.
+	 * Internal implementation of a simple flag lock. See comments in
+	 * locks.hh and locks.h for more details.
 	 */
 	struct InternalFlagLock : public FlagLockState
 	{
@@ -139,11 +126,8 @@ namespace
 	};
 
 	/**
-	 * A simple ticket lock.
-	 *
-	 * A ticket lock ensures that threads that arrive are serviced in order,
-	 * without regard for priorities.  It has no mechanism for tracking tickets
-	 * that are discarded and so does not implement a `try_lock` API.
+	 * Internal implementation of a simple ticket lock. See comments in
+	 * locks.hh and locks.h for more details.
 	 */
 	struct InternalTicketLock : public TicketLockState
 	{


### PR DESCRIPTION
This PR contains three commits:

- First one fixes some stale comments which I found somewhat confusing
- Second one implements lock destruction (see issue #168)
- Last one does some cleanup in the locking tests for coherence and consistency

It would be nice to implement `test_destruct_flag_lock_acquire` with templating, unfortunately we are hitting a compiler bug which prevents us from doing that. Let's add templating to that function once the compiler bug is reported and fixed.