### PR TITLE
Smoothen onboarding with Arty A7

### DIFF
--- a/scripts/ibex-build-firmware.sh
+++ b/scripts/ibex-build-firmware.sh
@@ -22,6 +22,11 @@ fi
 
 echo Using ${OBJCOPY}...
 
+# Create the firmware directory if it does not already exist
+if [ ! -d "firmware" ]; then
+	mkdir firmware
+fi
+
 # Convert the ELF file to a hex file for the simulator
 ${OBJCOPY} -O binary $1 - | hexdump -v -e '"%08X" "\n"' > firmware/cpu0_iram.vhx
 # Add a newline at the end of the vhx file


### PR DESCRIPTION
This PR addresses two issues when onboarding with the Arty A7:
- The `ibex-build-firmware.sh` script has a bug that makes it fail when a directory is not manually created
- There is no documentation on how to load the firmware onto the FPGA