### PR TITLE
Bug fixing and asserts in the locking subsystem

### DIFF
--- a/sdk/lib/locks/locks.cc
+++ b/sdk/lib/locks/locks.cc
@@ -230,8 +230,12 @@ namespace
 		 */
 		void unlock()
 		{
-			uint32_t currentSnapshot = ++current;
-			if (next > currentSnapshot)
+			uint32_t currentSnapshot = current++;
+
+			// If `next != current` when we entered this function,
+			// then there are waiters (because we had `next ==
+			// current` when took the lock)
+			if (next != currentSnapshot)
 			{
 				current.notify_all();
 			}

--- a/sdk/lib/locks/xmake.lua
+++ b/sdk/lib/locks/xmake.lua
@@ -1,5 +1,11 @@
 includes("../atomic")
 
+debugOption("locks")
+
 library("locks")
+  add_rules("cheriot.component-debug")
   add_deps("atomic4")
   add_files("locks.cc", "semaphore.cc")
+  on_load(function (target)
+	target:set('cheriot.debug-name', "locks")
+  end)


### PR DESCRIPTION
This PR contributes:
- Bug fixing for an overflow bug in ticket locks
- Add asserts to catch potential bugs in the locking subsystem
- Expose debugging options for the locking subsystem through the build system