### PR TITLE
Add a script to measure firmware image sizes

### DIFF
--- a/scripts/ibex-build-firmware.sh
+++ b/scripts/ibex-build-firmware.sh
@@ -1,24 +1,9 @@
 #!/bin/sh
 
-# Find objcopy.
-OBJCOPY=llvm-objcopy
-if ! type ${OBJCOPY} >/dev/null 2>&1 ; then
-	if [ -x "/cheriot-tools/bin/llvm-objcopy" ] ; then
-		OBJCOPY=/cheriot-tools/bin/llvm-objcopy
-	else
-		if [ -n "${TOOLS_PATH}" ] ; then
-			if [ -x "${TOOLS_PATH}/llvm-objcopy" ] ; then
-				echo found ${TOOLS_PATH}/llvm-objcopy
-				OBJCOPY=${TOOLS_PATH}/llvm-objcopy
-			fi
-		fi
-	fi
-fi
+SCRIPT_DIRECTORY="$(dirname "$(realpath "$0")")"
+. ${SCRIPT_DIRECTORY}/includes/helper_find_llvm_install.sh
 
-if [ ! -x ${OBJCOPY} ] ; then
-	echo Unable to locate llvm-objcopy, please set TOOLS_PATH to the directory containing the LLVM toolchain.
-	exit 1
-fi
+OBJCOPY=$(find_llvm_tool_required llvm-objcopy)
 
 echo Using ${OBJCOPY}...
 

--- a/scripts/includes/helper_find_llvm_install.sh
+++ b/scripts/includes/helper_find_llvm_install.sh
@@ -1,0 +1,40 @@
+# Constant: location of the custom tool binaries in the dev container
+DEV_CONTAINER_BIN="/cheriot-tools/bin/"
+
+# Finds location of a given LLVM tool on the system.
+#
+# Argument 1: name of the LLVM tool to find (e.g.,
+#             `llvm-objdump`, `llvm-objcopy`)
+find_llvm_tool() {
+	TOOL_NAME=$1
+	LLVM_TOOL=${TOOL_NAME}
+	if ! type ${LLVM_TOOL} >/dev/null 2>&1 ; then
+		FROM_DEV_CONTAINER="${DEV_CONTAINER_BIN}/${TOOL_NAME}"
+		if [ -x "${FROM_DEV_CONTAINER}" ] ; then
+			LLVM_TOOL=${FROM_DEV_CONTAINER}
+		else
+			if [ -n "${TOOLS_PATH}" ] ; then
+				WITH_TOOLS_PATH_SET="${TOOLS_PATH}/${TOOL_NAME}"
+				if [ -x "${WITH_TOOLS_PATH_SET}" ] ; then
+					LLVM_TOOL=${WITH_TOOLS_PATH_SET}
+				fi
+			fi
+		fi
+	fi
+	echo "${LLVM_TOOL}"
+}
+
+# Wrapper for `find_llvm_tool` that does `exit 1` with an error message if the
+# tool cannot be found.
+#
+# Arguments are the same as `find_llvm_tool`.
+find_llvm_tool_required() {
+	LLVM_TOOL=$(find_llvm_tool $1)
+
+	if [ ! -x ${LLVM_TOOL} ] ; then
+		echo Unable to locate $1, please set TOOLS_PATH to the directory containing the LLVM toolchain.
+		exit 1
+	fi
+
+	echo "${LLVM_TOOL}"
+}

--- a/scripts/output_code_size.sh
+++ b/scripts/output_code_size.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+SCRIPT_DIRECTORY="$(dirname "$(realpath "$0")")"
+. ${SCRIPT_DIRECTORY}/includes/helper_find_llvm_install.sh
+
+OBJDUMP=$(find_llvm_tool_required llvm-objdump)
+
+MACHINE_READABLE=0
+
+print_compartment_size() {
+	# Print all sections that match passed compartment name (potentially
+	# multiple ones, as compartments covers code and various data
+	# sections), and sum their sizes.
+	#
+	# Note that this does not validate compartment names. An invalid
+	# compartment name may return either 0kB, or an arbitrary number if the
+	# provided name matches legitimate compartments. This would be nice to
+	# fix at some point.
+	SIZE=$(${OBJDUMP} --headers $1 | grep -i $2 |
+		awk '{ sum += "0x"$3 } END { print sum}')
+
+	if [ "$MACHINE_READABLE" -eq 0 ]; then
+		KB_SIZE=$(echo $SIZE | awk '{ print ($1 / 1024) "kB"}')
+		echo "Size of compartment '$2': ${KB_SIZE}"
+	else
+		echo "${SIZE}"
+	fi
+}
+
+print_full_code_size() {
+	# Print all sections between the start of the firmware (`loader_start`)
+	# and the end of `__cap_relocs`, and sum the sizes of sections
+	SIZE=$(${OBJDUMP} --headers $1 |
+		awk '/loader_start/{f=1} /__cap_relocs/{f=0;print} f' |
+		awk '{ sum += "0x"$3 } END { print sum}')
+
+	if [ "$MACHINE_READABLE" -eq 0 ]; then
+		KB_SIZE=$(echo $SIZE | awk '{ print ($1 / 1024) "kB"}')
+		echo "Size of the full binary: ${KB_SIZE}"
+	else
+		echo "${SIZE}"
+	fi
+}
+
+help() {
+   echo "Determine the size of a CHERIoT firmware image."
+   echo
+   echo "Syntax: $(basename "$0") {-m} [-h|-c|-f]"
+   echo "  -m                                         Enable machine-readable output in B."
+   echo "                                             Optional, must come before -c/-f."
+   echo "  -h                                         Print this help."
+   echo "  -f [firmware location]                     Print the size of the entire firmware image."
+   echo "  -c [firmware location] [compartment name]  Print the size of passed compartment."
+   echo
+}
+
+if [ "$#" -eq 0 ]; then
+	echo "Error: Arguments missing."
+	help
+	exit
+fi
+
+while getopts ":hcfm" opt; do
+case $opt in
+	h)
+		help
+		exit;;
+	m)
+		MACHINE_READABLE=1
+		;;
+	c)
+		EXPECTED=$(( 3 + ${MACHINE_READABLE}))
+		if [ "$#" -ne "${EXPECTED}" ]; then
+			echo "Error: Argument number incorrect."
+			help
+			exit
+		fi
+
+		shift $((OPTIND-1))
+		print_compartment_size $@
+		exit;;
+	f)
+		EXPECTED=$(( 2 + ${MACHINE_READABLE}))
+		if [ "$#" -ne "${EXPECTED}" ]; then
+			echo "Error: Argument number incorrect."
+			help
+			exit
+		fi
+
+		shift $((OPTIND-1))
+		print_full_code_size $@
+		exit;;
+	\?)
+		echo "Error: Invalid option."
+		help
+		exit;;
+esac
+done


### PR DESCRIPTION
We need a standard and common way of measuring firmware images sizes to optimize this metric.

Add a helper script to `scripts/` to measure this.

Re-use the LLVM tool finding bit of the Ibex script by factoring it out in its own file.