### PR TITLE
Add objcopy to LLVM build instructions

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -125,7 +125,7 @@ This can be inside the source checkout but you may prefer to build somewhere els
 Next, use `cmake` to configure the build:
 
 ```sh
-$ cmake ${LLVM_PATH}/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld" -DCMAKE_INSTALL_PREFIX=install -DLLVM_ENABLE_UNWIND_TABLES=NO -DLLVM_TARGETS_TO_BUILD=RISCV -DLLVM_DISTRIBUTION_COMPONENTS="clang;clangd;lld;llvm-objdump" -G Ninja
+$ cmake ${LLVM_PATH}/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld" -DCMAKE_INSTALL_PREFIX=install -DLLVM_ENABLE_UNWIND_TABLES=NO -DLLVM_TARGETS_TO_BUILD=RISCV -DLLVM_DISTRIBUTION_COMPONENTS="clang;clangd;lld;llvm-objdump;llvm-objcopy" -G Ninja
 ```
 
 It is very strongly recommended that you do a release build, debug builds can take several minutes to compile files that take seconds with release builds.


### PR DESCRIPTION
We need objcopy for the bootloader:
https://github.com/CHERIoT-Platform/cheriot-safe-uart-boot-rom/blob/92e9673ab2c65a621e6e3411d14d21275dcab5a1/Makefile#L4

I found how to do this in this file:
https://github.com/CHERIoT-Platform/llvm-project/blob/dfbd2b1fdd33746ca9e615feb7852013e8f3966a/.cirrus.yml#L49