### PR TITLE
Add strict permissions and bounds mode to `CHERI::check_pointer`

### DIFF
--- a/sdk/include/cheri.hh
+++ b/sdk/include/cheri.hh
@@ -1063,10 +1063,9 @@ namespace CHERI
 	 * constants needed before performing an indirect call to
 	 * `::check_pointer`.
 	 */
-	template<PermissionSet Permissions     = PermissionSet{Permission::Load},
-	         typename T                    = void,
-	         bool CheckStack               = true,
-	         bool EnforceStrictPermissions = false>
+	template<PermissionSet Permissions = PermissionSet{Permission::Load},
+	         bool          CheckStack  = true,
+	         bool          EnforceStrictPermissions = false>
 	__always_inline inline bool check_pointer(
 	  auto  &ptr,
 	  size_t space = sizeof(

--- a/sdk/include/cheri.hh
+++ b/sdk/include/cheri.hh
@@ -1054,9 +1054,9 @@ namespace CHERI
 	 * library) by passing `false` for `CheckStack`.
 	 *
 	 * If `EnforceStrictPermissions` is set to `true`, this will also set
-	 * the permissions of passed capability reference to `Permissions`.
-	 * This is useful for detecting cases where compartments ask for less
-	 * permissions than they actually require.
+	 * the permissions of passed capability reference to `Permissions`, and
+	 * its bounds to `space`. This is useful for detecting cases where
+	 * compartments ask for less permissions than they actually require.
 	 *
 	 * This function is provided as a wrapper for the `::check_pointer` C
 	 * API. It is always inlined. For each call site, it materialises the
@@ -1100,7 +1100,7 @@ namespace CHERI
 			  ptr.get(), space, Permissions.as_raw(), StackCheckNeeded);
 		}
 		// If passed `EnforceStrictPermissions`, set the permissions
-		// of `ptr` to `Permissions`
+		// of `ptr` to `Permissions`, and its bounds to `space`
 		if constexpr (EnforceStrictPermissions)
 		{
 			if (isValid)
@@ -1109,13 +1109,15 @@ namespace CHERI
 				{
 					Capability cap{ptr};
 					cap.permissions() &= Permissions;
-					ptr = cap.get();
+					cap.bounds() = space;
+					ptr          = cap.get();
 				}
 				else
 				{
 					Capability cap{ptr.get()};
 					cap.permissions() &= Permissions;
-					ptr = cap.get();
+					cap.bounds() = space;
+					ptr          = cap.get();
 				}
 			}
 		}

--- a/sdk/lib/queue/queue.cc
+++ b/sdk/lib/queue/queue.cc
@@ -458,9 +458,8 @@ int queue_send(Timeout *timeout, struct QueueHandle *handle, const void *src)
 				Debug::log("Claim failed: {}", claim);
 				return claim;
 			}
-			if (!check_pointer<PermissionSet{Permission::Load},
-			                   const void,
-			                   false>(src, handle->elementSize))
+			if (!check_pointer<PermissionSet{Permission::Load}, false>(
+			      src, handle->elementSize))
 			{
 				drop_claims();
 				Debug::log("Load / bounds check failed: {}");
@@ -524,7 +523,7 @@ int queue_receive(Timeout *timeout, struct QueueHandle *handle, void *dst)
 			{
 				return claim;
 			}
-			if (!check_pointer<PermissionSet{Permission::Store}, void, false>(
+			if (!check_pointer<PermissionSet{Permission::Store}, false>(
 			      dst, handle->elementSize))
 			{
 				drop_claims();

--- a/tests/check_pointer-test.cc
+++ b/tests/check_pointer-test.cc
@@ -14,15 +14,18 @@ using namespace CHERI;
  * This test checks the following:
  *
  * 1. When passed `EnforceStrictPermissions = false` (default behavior),
- *    `CHERI::check_pointer` does not modify the permissions of passed
- *    capability with a Capability argument.
+ *    `CHERI::check_pointer` does not modify the permissions and length of
+ *    passed capability with a Capability argument.
  * 2. When passed `EnforceStrictPermissions = false` (default behavior),
- *    `CHERI::check_pointer` does not modify the permissions of passed
- *    capability with a raw capability argument.
+ *    `CHERI::check_pointer` does not modify the permissions and length of
+ *    passed capability with a raw capability argument.
  * 3. When passed `EnforceStrictPermissions = true`, `CHERI::check_pointer`
- *    changes permissions appropriately with a Capability argument.
+ *    changes permissions and length appropriately with a Capability argument.
  * 4. When passed `EnforceStrictPermissions = true`, `CHERI::check_pointer`
- *    changes permissions appropriately with a raw capability argument.
+ *    changes permissions and length appropriately with a raw capability
+ *    argument.
+ * 5. For both 3. and 4., it also checks that `EnforceStrictPermissions = true`
+ *    does not invalidate the capability.
  */
 void check_pointer_strict_mode(int *ptr)
 {
@@ -33,18 +36,27 @@ void check_pointer_strict_mode(int *ptr)
 	debug_log("Test with Capability argument.");
 
 	PermissionSet permissionsAtCreation = cap.permissions();
+	auto          boundsAtCreation      = cap.bounds();
 
 	// Check that the capability has > load permissions at creation.
 	TEST(permissionsAtCreation.contains(Permission::Load, Permission::Store),
 	     "Permissions of new capability do not include load/store.");
 
+	// Check that the capability has length > 1 at creation.
+	TEST(boundsAtCreation > 1,
+	     "Permissions of new capability do not include load/store.");
+
 	// We will detect if `check_pointer` changes the permissions because we
-	// are calling with load only here.
+	// are calling load only and bounds = 1 here.
 	TEST(check_pointer<PermissionSet{Permission::Load}>(cap, 1),
 	     "Cannot check valid capability (calling with Capability object).");
 
 	TEST(cap.permissions() == permissionsAtCreation,
 	     "check_pointer reduced the permissions of passed Capability "
+	     "object although EnforceStrictPermissions = false.");
+
+	TEST(cap.bounds() == boundsAtCreation,
+	     "check_pointer reduced the bounds of passed Capability "
 	     "object although EnforceStrictPermissions = false.");
 
 	debug_log("Test with raw capability argument.");
@@ -56,6 +68,10 @@ void check_pointer_strict_mode(int *ptr)
 
 	TEST(capShouldBeTheSame.permissions() == permissionsAtCreation,
 	     "check_pointer reduced the permissions of passed raw "
+	     "capability although EnforceStrictPermissions = false.");
+
+	TEST(capShouldBeTheSame.bounds() == boundsAtCreation,
+	     "check_pointer reduced the bounds of passed Capability "
 	     "capability although EnforceStrictPermissions = false.");
 
 	debug_log("Test check_pointer with EnforceStrictPermissions = true.");
@@ -72,6 +88,15 @@ void check_pointer_strict_mode(int *ptr)
 	TEST(cap.permissions() == PermissionSet{Permission::Load},
 	     "check_pointer did not reduce the permissions of passed Capability "
 	     "object although EnforceStrictPermissions = true.");
+
+	// The bounds should now be 1.
+	TEST(cap.bounds() == 1,
+	     "check_pointer did not reduce the bounds of passed Capability "
+	     "object although EnforceStrictPermissions = true.");
+
+	TEST(check_pointer<PermissionSet{Permission::Load}>(cap, 1),
+	     "EnforceStrictPermissions = true breaks the capability when called "
+	     "with a Capability object.");
 
 	debug_log("Test with raw capability argument.");
 
@@ -93,6 +118,14 @@ void check_pointer_strict_mode(int *ptr)
 	TEST(cap3.permissions() == PermissionSet{Permission::Load},
 	     "check_pointer did not reduce the permissions of passed raw "
 	     "capability although EnforceStrictPermissions = true.");
+
+	TEST(cap3.bounds() == 1,
+	     "check_pointer did not reduce the bounds of passed raw "
+	     "capability although EnforceStrictPermissions = true.");
+
+	TEST(check_pointer<PermissionSet{Permission::Load}>(ptr, 1),
+	     "EnforceStrictPermissions = true breaks the capability when called "
+	     "with a raw capability.");
 }
 
 void test_check_pointer()

--- a/tests/check_pointer-test.cc
+++ b/tests/check_pointer-test.cc
@@ -1,0 +1,101 @@
+// Copyright CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#define TEST_NAME "Test check_pointer"
+#include "tests.hh"
+
+int object;
+
+using namespace CHERI;
+
+/**
+ * Test the `EnforceStrictPermissions` feature of `CHERI::check_pointer`.
+ *
+ * This test checks the following:
+ *
+ * 1. When passed `EnforceStrictPermissions = false` (default behavior),
+ *    `CHERI::check_pointer` does not modify the permissions of passed
+ *    capability with a Capability argument.
+ * 2. When passed `EnforceStrictPermissions = false` (default behavior),
+ *    `CHERI::check_pointer` does not modify the permissions of passed
+ *    capability with a raw capability argument.
+ * 3. When passed `EnforceStrictPermissions = true`, `CHERI::check_pointer`
+ *    changes permissions appropriately with a Capability argument.
+ * 4. When passed `EnforceStrictPermissions = true`, `CHERI::check_pointer`
+ *    changes permissions appropriately with a raw capability argument.
+ */
+void check_pointer_strict_mode(int *ptr)
+{
+	bool       isValid;
+	Capability cap{ptr};
+
+	debug_log("Test default check_pointer (EnforceStrictPermissions = false).");
+	debug_log("Test with Capability argument.");
+
+	PermissionSet permissionsAtCreation = cap.permissions();
+
+	// Check that the capability has > load permissions at creation.
+	TEST(permissionsAtCreation.contains(Permission::Load, Permission::Store),
+	     "Permissions of new capability do not include load/store.");
+
+	// We will detect if `check_pointer` changes the permissions because we
+	// are calling with load only here.
+	TEST(check_pointer<PermissionSet{Permission::Load}>(cap, 1),
+	     "Cannot check valid capability (calling with Capability object).");
+
+	TEST(cap.permissions() == permissionsAtCreation,
+	     "check_pointer reduced the permissions of passed Capability "
+	     "object although EnforceStrictPermissions = false.");
+
+	debug_log("Test with raw capability argument.");
+
+	TEST(check_pointer<PermissionSet{Permission::Load}>(ptr, 1),
+	     "Cannot check valid capability (calling with raw capability).");
+
+	Capability capShouldBeTheSame{ptr};
+
+	TEST(capShouldBeTheSame.permissions() == permissionsAtCreation,
+	     "check_pointer reduced the permissions of passed raw "
+	     "capability although EnforceStrictPermissions = false.");
+
+	debug_log("Test check_pointer with EnforceStrictPermissions = true.");
+	debug_log("Test with Capability argument.");
+
+	// We can re-use `cap` here because it was not changed.
+	isValid =
+	  check_pointer<PermissionSet{Permission::Load}, void, true, true>(cap, 1);
+	TEST(isValid,
+	     "Cannot check valid capability when EnforceStrictPermissions = true "
+	     "(calling with Capability object).");
+
+	// The capability should now be load-only.
+	TEST(cap.permissions() == PermissionSet{Permission::Load},
+	     "check_pointer did not reduce the permissions of passed Capability "
+	     "object although EnforceStrictPermissions = true.");
+
+	debug_log("Test with raw capability argument.");
+
+	// We cannot re-use `cap` because it was changed.
+	Capability cap2{ptr};
+	TEST(
+	  cap2.permissions() == permissionsAtCreation,
+	  "Permissions of freshly created capability do not include load/store.");
+
+	isValid =
+	  check_pointer<PermissionSet{Permission::Load}, void, true, true>(ptr, 1);
+	TEST(isValid,
+	     "Cannot check valid capability when EnforceStrictPermissions = true "
+	     "(calling with raw capability).");
+
+	// We need to create a new Capability object with the updated pointer
+	// to check its permissions.
+	Capability cap3{ptr};
+	TEST(cap3.permissions() == PermissionSet{Permission::Load},
+	     "check_pointer did not reduce the permissions of passed raw "
+	     "capability although EnforceStrictPermissions = true.");
+}
+
+void test_check_pointer()
+{
+	check_pointer_strict_mode(&object);
+}

--- a/tests/check_pointer-test.cc
+++ b/tests/check_pointer-test.cc
@@ -79,7 +79,7 @@ void check_pointer_strict_mode(int *ptr)
 
 	// We can re-use `cap` here because it was not changed.
 	isValid =
-	  check_pointer<PermissionSet{Permission::Load}, void, true, true>(cap, 1);
+	  check_pointer<PermissionSet{Permission::Load}, true, true>(cap, 1);
 	TEST(isValid,
 	     "Cannot check valid capability when EnforceStrictPermissions = true "
 	     "(calling with Capability object).");
@@ -107,7 +107,7 @@ void check_pointer_strict_mode(int *ptr)
 	  "Permissions of freshly created capability do not include load/store.");
 
 	isValid =
-	  check_pointer<PermissionSet{Permission::Load}, void, true, true>(ptr, 1);
+	  check_pointer<PermissionSet{Permission::Load}, true, true>(ptr, 1);
 	TEST(isValid,
 	     "Cannot check valid capability when EnforceStrictPermissions = true "
 	     "(calling with raw capability).");

--- a/tests/static_sealing_inner.cc
+++ b/tests/static_sealing_inner.cc
@@ -45,7 +45,7 @@ void test_static_sealed_object(Sealed<TestType> obj)
 	                                  Permission::LoadStoreCapability,
 	                                  Permission::LoadMutable,
 	                                  Permission::LoadGlobal,
-	                                  Permission::Global}>(unsealed.get(), 1)),
+	                                  Permission::Global}>(unsealed, 1)),
 	     "Incorrect permissions on unsealed statically sealed object {}",
 	     unsealed);
 }

--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -108,6 +108,7 @@ void __cheri_compartment("test_runner") run_tests()
 		run_timed("Static sealing", test_static_sealing);
 		run_timed("Crash recovery", test_crash_recovery);
 		run_timed("Compartment calls", test_compartment_call);
+		run_timed("check_pointer", test_check_pointer);
 		run_timed("Stacks exhaustion in the switcher", test_stack);
 		run_timed("Thread pool", test_thread_pool);
 		run_timed("Global Constructors", test_global_constructors);

--- a/tests/tests.hh
+++ b/tests/tests.hh
@@ -16,6 +16,7 @@ __cheri_compartment("crash_recovery_test") void test_crash_recovery();
 __cheri_compartment("multiwaiter_test") void test_multiwaiter();
 __cheri_compartment("stack_test") void test_stack();
 __cheri_compartment("compartment_calls_test") void test_compartment_call();
+__cheri_compartment("check_pointer_test") void test_check_pointer();
 __cheri_compartment("static_sealing_test") void test_static_sealing();
 
 // Simple tests don't need a separate compartment.

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -75,6 +75,7 @@ compartment("compartment_calls_inner")
 compartment("compartment_calls_inner_with_handler")
     add_files("compartment_calls_inner_with_handler.cc")
 test("compartment_calls")
+test("check_pointer")
 
 includes(path.join(sdkdir, "lib"))
 
@@ -103,6 +104,7 @@ firmware("test-suite")
     add_deps("ccompile_test")
     add_deps("stack_test", "stack_integrity_thread")
     add_deps("compartment_calls_test", "compartment_calls_inner", "compartment_calls_inner_with_handler")
+    add_deps("check_pointer_test")
     -- Set the thread entry point to the test runner.
     on_load(function(target)
         target:values_set("board", "$(board)")


### PR DESCRIPTION
This PR adds a new strict mode to `CHERI::check_pointer` which can be enabled by setting the `EnforceStrictPermissions` templating argument to `true`.

In this mode, `check_pointer` removes permissions which are not declared in `Permissions` from the passed `ptr` reference, and adjusts its bounds to match `space`.

This is useful for detecting cases where compartments ask for less permissions than they actually require.

Extend the test suite to test this new feature.