### PR TITLE
Update LoadCapCGP assembly.

### DIFF
--- a/sdk/include/assembly-helpers.s
+++ b/sdk/include/assembly-helpers.s
@@ -83,6 +83,7 @@
  * register.
  */
 .macro LoadCapCGP register symbol
+1:
 	auicgp		\register, %cheriot_compartment_hi(\symbol)
-	clc			\register, %cheriot_compartment_lo_i(\symbol)(\register)
+	clc			\register, %cheriot_compartment_lo_i(1b)(\register)
 .endm


### PR DESCRIPTION
This now works like AUIPCC, from a relocations perspective, but the linker still accepts the old format.  This updates the assembly to not require the compat paths (we'll keep them for a while though).