### PR TITLE
Add a helper for checking timeouts.

### DIFF
--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -795,13 +795,6 @@ namespace
 		  *capability, *chunk, bodySize, isPrecise, reallyFree);
 	}
 
-	bool timeout_is_valid(Timeout *timeout)
-	{
-		return !heap_address_is_valid(timeout) &&
-		       check_pointer<PermissionSet{Permission::Load,
-		                                   Permission::Store}>(timeout);
-	}
-
 } // namespace
 
 size_t heap_quota_remaining(struct SObjStruct *heapCapability)
@@ -832,7 +825,7 @@ void heap_quarantine_empty()
 
 void *heap_allocate(Timeout *timeout, SObj heapCapability, size_t bytes)
 {
-	if (!timeout_is_valid(timeout))
+	if (!check_timeout_pointer(timeout))
 	{
 		return nullptr;
 	}
@@ -948,7 +941,7 @@ void *heap_allocate_array(Timeout *timeout,
                           size_t   nElements,
                           size_t   elemSize)
 {
-	if (!timeout_is_valid(timeout))
+	if (!check_timeout_pointer(timeout))
 	{
 		return nullptr;
 	}
@@ -1094,7 +1087,7 @@ SObj token_sealed_unsealed_alloc(Timeout *timeout,
                                  size_t   sz,
                                  void   **unsealed)
 {
-	if (!timeout_is_valid(timeout))
+	if (!check_timeout_pointer(timeout))
 	{
 		return INVALID_SOBJ;
 	}

--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -358,15 +358,6 @@ namespace sched
 		}
 	}
 
-	/**
-	 * Check that a timeout pointer is usable.
-	 */
-	bool check_timeout_pointer(Timeout *timeout)
-	{
-		return check_pointer<PermissionSet{Permission::Load,
-		                                   Permission::Store}>(timeout);
-	}
-
 	/// Lock used to serialise deallocations.
 	FlagLock deallocLock;
 

--- a/sdk/include/cheri.h
+++ b/sdk/include/cheri.h
@@ -6,6 +6,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct Timeout;
+
 /**
  * Checks that `ptr` is valid, unsealed, has at least `rawPermissions`, and has
  * at least `space` bytes after the current offset.
@@ -21,3 +23,10 @@ bool __cheri_libcall check_pointer(const void *ptr,
                                    size_t      space,
                                    uint32_t    rawPermissions,
                                    bool        checkStackNeeded);
+
+/**
+ * Check that the argument is a valid pointer to a `Timeout` structure.  This
+ * must have read/write permissions, be unsealed, and must not be a heap
+ * address.
+ */
+bool __cheri_libcall check_timeout_pointer(const struct Timeout *timeout);


### PR DESCRIPTION
This is the code that was in the allocator, generalised for other uses. Factoring this out should reduce code size and ensure that a consistent check is applied everywhere (a weaker check would break if passed into the allocator, for example).

Note: This increases the size of the test suite by 8 bytes, but only because it also fixes a missing check.