### PR TITLE
Fix unlimited timeouts.

### DIFF
--- a/sdk/include/timeout.h
+++ b/sdk/include/timeout.h
@@ -38,7 +38,9 @@ typedef struct Timeout
 	 */
 	Ticks elapsed __if_cxx(= 0);
 	/**
-	 * The remaining time.  This is clamped at 0 on subtraction.
+	 * The remaining time. This is clamped at 0 on subtraction. A special
+	 * value of `UnlimitedTimeout` can be set to represent an unlimited
+	 * timeout.
 	 */
 	Ticks remaining;
 #ifdef __cplusplus
@@ -68,7 +70,8 @@ typedef struct Timeout
 		{
 			elapsed = UnlimitedTimeout;
 		}
-		if (__builtin_sub_overflow(remaining, time, &remaining))
+		if (remaining != UnlimitedTimeout &&
+		    __builtin_sub_overflow(remaining, time, &remaining))
 		{
 			remaining = 0;
 		}

--- a/tests/misc-test.cc
+++ b/tests/misc-test.cc
@@ -1,0 +1,53 @@
+// Copyright CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#define TEST_NAME "Test misc APIs"
+#include "tests.hh"
+#include <timeout.h>
+
+/**
+ * Test timeouts.
+ *
+ * This test checks the following:
+ *
+ * - A timeout of zero would not block.
+ * - `elapse` saturates values, i.e., a `remaining` value of zero will still be
+ *   zero after a call to `elapse`, and an `elapsed` value of `UINT32_MAX`
+ *   would still be `UINT32_MAX` after a call to `elapse`.
+ * - An unlimited timeout is really unlimited, i.e., a call to `elapse` does
+ *   not modify its `remaining` value, which blocks.
+ */
+void check_timeouts()
+{
+	debug_log("Test timeouts.");
+
+	// Create a zero timeout.
+	Timeout t{0};
+	// Ensure that a zero timeout does not block.
+	TEST(!t.may_block(), "A zero timeout should not block.");
+
+	// Create a zero timer with maximum elapsed time.
+	t = Timeout{UINT32_MAX /* elapsed */, 0 /* remaining */};
+	// Ensure that a call to `elapse` saturates both `elapsed` and
+	// `remaining`.
+	t.elapse(42);
+	TEST(t.remaining == 0,
+	     "`elapse` does not saturate the `remaining` value of a zero timer.");
+	TEST(t.elapsed == UINT32_MAX,
+	     "`elapse` does not saturate the `elapsed` value of a zero timer.");
+
+	// Create an unlimited timeout.
+	t = Timeout{UnlimitedTimeout /* remaining */};
+	// Ensure that a call to `elapse` does not modify the `remaining` value
+	// of the unlimited timeout.
+	t.elapse(42);
+	TEST(t.remaining == UnlimitedTimeout,
+	     "`elapse` alters the remaining value of an unlimited timeout.");
+	// Ensure that an unlimited timeout blocks.
+	TEST(t.may_block(), "An unlimited timeout should block.");
+}
+
+void test_misc()
+{
+	check_timeouts();
+}

--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -109,6 +109,7 @@ void __cheri_compartment("test_runner") run_tests()
 		run_timed("Crash recovery", test_crash_recovery);
 		run_timed("Compartment calls", test_compartment_call);
 		run_timed("check_pointer", test_check_pointer);
+		run_timed("Misc APIs", test_misc);
 		run_timed("Stacks exhaustion in the switcher", test_stack);
 		run_timed("Thread pool", test_thread_pool);
 		run_timed("Global Constructors", test_global_constructors);

--- a/tests/tests.hh
+++ b/tests/tests.hh
@@ -17,6 +17,7 @@ __cheri_compartment("multiwaiter_test") void test_multiwaiter();
 __cheri_compartment("stack_test") void test_stack();
 __cheri_compartment("compartment_calls_test") void test_compartment_call();
 __cheri_compartment("check_pointer_test") void test_check_pointer();
+__cheri_compartment("misc_test") void test_misc();
 __cheri_compartment("static_sealing_test") void test_static_sealing();
 
 // Simple tests don't need a separate compartment.

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -76,6 +76,8 @@ compartment("compartment_calls_inner_with_handler")
     add_files("compartment_calls_inner_with_handler.cc")
 test("compartment_calls")
 test("check_pointer")
+-- Test various APIs that are too small to deserve their own test file
+test("misc")
 
 includes(path.join(sdkdir, "lib"))
 
@@ -105,6 +107,7 @@ firmware("test-suite")
     add_deps("stack_test", "stack_integrity_thread")
     add_deps("compartment_calls_test", "compartment_calls_inner", "compartment_calls_inner_with_handler")
     add_deps("check_pointer_test")
+    add_deps("misc_test")
     -- Set the thread entry point to the test runner.
     on_load(function(target)
         target:values_set("board", "$(board)")


### PR DESCRIPTION
Currently unlimited timeouts are not really unlimited, because we still do the substraction in `elapse`. Fix this by only doing the substraction when remaining is not `UnlimitedTimeout`.

While at it, improve the documentation, and add a test.