### PR TITLE
Add token_obj_can_destroy API.

### DIFF
--- a/sdk/include/token.h
+++ b/sdk/include/token.h
@@ -90,6 +90,16 @@ SObj __cheri_compartment("alloc")
 int __cheri_compartment("alloc")
   token_obj_destroy(struct SObjStruct *heapCapability, SKey, SObj);
 
+/**
+ * Check whether the pair of a sealing key and a heap capability can unseal a
+ * sealed object.
+ *
+ * Returns 0 on success, `-EINVAL` if the key or object is not valid, or one of
+ * the errors from `heap_can_free` if the free would fail for other reasons.
+ */
+int __cheri_compartment("alloc")
+  token_obj_can_destroy(SObj heapCapability, SKey key, SObj object);
+
 __END_DECLS
 
 #ifdef __cplusplus

--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -452,6 +452,24 @@ namespace
 		TEST(sealedPointer.is_sealed(), "Failed to allocate sealed capability");
 		TEST(!Capability{unsealedCapability}.is_sealed(),
 		     "Failed to allocate sealed capability");
+
+		int canFree =
+		  token_obj_can_destroy(SECOND_HEAP, sealingCapability, sealedPointer);
+		TEST(canFree == 0,
+		     "Should be able to free a sealed heap capability with the correct "
+		     "pair of capabilities but failed with {}",
+		     canFree);
+		canFree = token_obj_can_destroy(
+		  MALLOC_CAPABILITY, sealingCapability, sealedPointer);
+		TEST(canFree != 0,
+		     "Should not be able to free a sealed capability with the wrong "
+		     "malloc capability but succeeded");
+		canFree = token_obj_can_destroy(
+		  SECOND_HEAP, STATIC_SEALING_TYPE(wrongSealingKey), sealedPointer);
+		TEST(canFree != 0,
+		     "Should not be able to free a sealed capability with the wrong "
+		     "sealing key but succeeded");
+
 		TEST(token_obj_destroy(
 		       MALLOC_CAPABILITY, sealingCapability, sealedPointer) != 0,
 		     "Freeing a sealed capability with the wrong allocator succeeded");


### PR DESCRIPTION
This mirrors heap_can_free, but works on a sealed objects.

This is useful for APIs like the TLS stack where there's some teardown necessary before freeing and if the free happens at the end then we've accidentally authorised something that we shouldn't.