### PR TITLE
Add a check that the unused bits in MMIO imports are unused.

### DIFF
--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <cdefs.h>
+
 // memcpy is exposed as a libcall in the standard library headers but we want
 // to ensure that our version is called directly and not exposed to anything
 // else.


### PR DESCRIPTION
This addresses the 'shouldn't silently fail' part of #182.  A subsequent change may allow it to also work, depending on use cases.