### PR TITLE
Add `memchr` to the standard library.

### DIFF
--- a/sdk/include/string.h
+++ b/sdk/include/string.h
@@ -6,17 +6,20 @@
 #include <stddef.h>
 #include <stdint.h>
 
-int __cheri_libcall    memcmp(const void *str1, const void *str2, size_t count);
-void *__cheri_libcall  memcpy(void *dest, const void *src, size_t n);
-void *__cheri_libcall  memset(void *, int, size_t);
-void *__cheri_libcall  memmove(void *dest, const void *src, size_t n);
-size_t __cheri_libcall strlen(const char *str);
-int __cheri_libcall    strncmp(const char *s1, const char *s2, size_t n);
-char *__cheri_libcall  strncpy(char *dest, const char *src, size_t n);
-int __cheri_libcall    strcmp(const char *s1, const char *s2);
-char *__cheri_libcall strnstr(const char *haystack, const char *needle, size_t haystackLength);
-char *__cheri_libcall  strchr(const char *s, int c);
-size_t __cheri_libcall strlcpy(char *dest, const char *src, size_t n);
+int __cheri_libcall   memcmp(const void *str1, const void *str2, size_t count);
+void *__cheri_libcall memcpy(void *dest, const void *src, size_t n);
+void *__cheri_libcall memset(void *, int, size_t);
+void *__cheri_libcall memmove(void *dest, const void *src, size_t n);
+const void *__cheri_libcall memchr(const void *, int, size_t);
+size_t __cheri_libcall      strlen(const char *str);
+int __cheri_libcall         strncmp(const char *s1, const char *s2, size_t n);
+char *__cheri_libcall       strncpy(char *dest, const char *src, size_t n);
+int __cheri_libcall         strcmp(const char *s1, const char *s2);
+char *__cheri_libcall       strnstr(const char *haystack,
+                                    const char *needle,
+                                    size_t      haystackLength);
+char *__cheri_libcall       strchr(const char *s, int c);
+size_t __cheri_libcall      strlcpy(char *dest, const char *src, size_t n);
 
 /**
  * Explicit bzero is a memset variant that the compiler is not permitted to
@@ -30,8 +33,8 @@ __always_inline static inline char *strcpy(char *dst, const char *src)
 	return dst + strlcpy(dst, src, SIZE_MAX);
 }
 
-
-__always_inline static inline char *strstr(const char *haystack, const char *needle)
+__always_inline static inline char *strstr(const char *haystack,
+                                           const char *needle)
 {
 	return strnstr(haystack, needle, SIZE_MAX);
 }

--- a/sdk/lib/string/memchr.c
+++ b/sdk/lib/string/memchr.c
@@ -1,0 +1,23 @@
+// Copyright SCI Semiconductor and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <string.h>
+
+const void *__cheri_libcall memchr(const void *voidString,
+                                   int         intChar,
+                                   size_t      n)
+{
+	const unsigned char  c = (unsigned char)intChar;
+	const unsigned char *s = (const unsigned char *)voidString;
+
+	for (size_t i = 0; i != n; i++)
+	{
+		if (*s == c)
+		{
+			return (const void *)s;
+		}
+		s++;
+	}
+
+	return NULL;
+}

--- a/sdk/lib/string/strchr.c
+++ b/sdk/lib/string/strchr.c
@@ -1,6 +1,6 @@
 #include <string.h>
 
-char *strchr(const char *s, int intChar)
+char *__cheri_libcall strchr(const char *s, int intChar)
 {
 	char c = (char)intChar;
 	while (*s != c)

--- a/sdk/lib/string/xmake.lua
+++ b/sdk/lib/string/xmake.lua
@@ -1,3 +1,3 @@
 library("string")
   set_default(false)
-  add_files("strcmp.c", "strlen.c", "strncpy.c", "strstr.cc", "strchr.c", "strlcpy.c")
+  add_files("strcmp.c", "strlen.c", "strncpy.c", "strstr.cc", "strchr.c", "strlcpy.c", "memchr.c")

--- a/tests/misc-test.cc
+++ b/tests/misc-test.cc
@@ -3,6 +3,7 @@
 
 #define TEST_NAME "Test misc APIs"
 #include "tests.hh"
+#include <string.h>
 #include <timeout.h>
 
 /**
@@ -47,7 +48,45 @@ void check_timeouts()
 	TEST(t.may_block(), "An unlimited timeout should block.");
 }
 
+/**
+ * Test memchr.
+ *
+ * This test checks the following:
+ *
+ * - memchr finds the first occurrence of the character when it is present
+ *   (test for different values, particularly the first and the last one).
+ * - memchr returns NULL when the string does not contain the character (test
+ *   for non-NULL terminated string).
+ * - memchr does not stop at \0 characters.
+ * - memchr returns NULL for 0-size pointers.
+ */
+void check_memchr()
+{
+	debug_log("Test memchr.");
+
+	char string[] = {'C', 'H', 'E', 'R', 'R', 'I', 'E', 'S'};
+
+	TEST(memchr(string, 'C', sizeof(string)) == &string[0],
+	     "memchr must return the first occurence of the character.");
+	TEST(memchr(string, 'R', sizeof(string)) == &string[3],
+	     "memchr must return the first occurence of the character.");
+	TEST(memchr(string, 'S', sizeof(string)) == &string[7],
+	     "memchr must return the first occurence of the character.");
+	TEST(memchr(string, 'X', sizeof(string)) == NULL,
+	     "memchr must return NULL when a character is not present.");
+
+	char stringWithNull[] = {'Y', 'E', 'S', '\0', 'N', 'O', '\0'};
+
+	TEST(memchr(stringWithNull, 'N', sizeof(stringWithNull)) ==
+	       &stringWithNull[4],
+	     "memchr must not stop at NULL characters.");
+
+	TEST(memchr(stringWithNull, 'N', 0) == NULL,
+	     "memchr must return NULL for zero-size pointers.");
+}
+
 void test_misc()
 {
 	check_timeouts();
+	check_memchr();
 }


### PR DESCRIPTION
This is small and necessary to have `std::string_view::find`, which is useful, among others, for validation of input in the network stack.

Add a small test for the implementation.