### PR TITLE
Remove reference to the patch_sail_riscv target.

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -204,7 +204,6 @@ Make sure that all of the relevant opam environment variables are set and build 
 ```
 $ cd cheriot-sail
 $ eval $(opam env)
-$ make patch_sail_riscv
 $ make csim
 ```
 


### PR DESCRIPTION
This went away when we moved the sail-riscv submodule to the CHERIoT-Platform org.

Reported by @gavinhoward