### PR TITLE
Fix `fail-simulator-on-error` handler issue with nullptr dereferences.

### DIFF
--- a/sdk/include/fail-simulator-on-error.h
+++ b/sdk/include/fail-simulator-on-error.h
@@ -72,7 +72,10 @@ compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval)
 		}
 		else
 		{
-			// An unexpected error -- log it and end the simulation with error.
+			// An unexpected error -- log it and end the simulation
+			// with error.  Note: handle CZR differently as
+			// `get_register_value` will return a nullptr which we
+			// cannot dereference.
 			DebugErrorHandler::log(
 			  "{} error at {} (return address: {}), with capability register "
 			  "{}: {}",
@@ -80,7 +83,9 @@ compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval)
 			  frame->pcc,
 			  frame->get_register_value<CHERI::RegisterNumber::CRA>(),
 			  registerNumber,
-			  *frame->get_register_value(registerNumber));
+			  registerNumber == CHERI::RegisterNumber::CZR
+			    ? nullptr
+			    : *frame->get_register_value(registerNumber));
 			simulation_exit(1);
 		}
 	}


### PR DESCRIPTION
`get_register_value` returns a nullptr when passed CZR, causing a crash in the error handler. We need to treat CZR as a special case.