### PR TITLE
Make the scheduler tickless

### DIFF
--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -291,7 +291,7 @@ namespace
 						// Drop and reacquire the lock while yielding.
 						// Sleep for a single tick.
 						g.unlock();
-						Timeout smallSleep{0};
+						Timeout smallSleep{1};
 						thread_sleep(&smallSleep);
 						if (!reacquire_lock(timeout, g, smallSleep.elapsed))
 						{

--- a/sdk/core/scheduler/timer.h
+++ b/sdk/core/scheduler/timer.h
@@ -26,36 +26,96 @@ namespace
 	  IsTimer<TimerCore>,
 	  "Platform's timer implementation does not meet the required interface");
 
+	/**
+	 * Timer interface.  Provides generic timer functionality to the scheduler,
+	 * wrapping the platform's timer device.
+	 */
 	class Timer final : private TimerCore
 	{
+		inline static uint64_t lastTickTime         = 0;
+		inline static uint64_t zeroTickTime         = 0;
+		inline static uint32_t accumulatedTickError = 0;
+
 		public:
+		/**
+		 * Perform any setup necessary for the timer device.
+		 */
 		static void interrupt_setup()
 		{
 			static_assert(TIMERCYCLES_PER_TICK <= UINT32_MAX,
 			              "Cycles per tick can't be represented in 32 bits. "
 			              "Double check your platform config");
 			init();
-			setnext(TIMERCYCLES_PER_TICK);
+			zeroTickTime = time();
 		}
 
-		static void do_interrupt()
+		/**
+		 * Expose the timer device's method for returning the current time.
+		 */
+		using TimerCore::time;
+
+		/**
+		 * Update the timer to fire the next timeout for the thread at the
+		 * front of the queue, or disable the timer if there are no threads
+		 * blocked with a timeout and no threads with the same priority.
+		 *
+		 * The scheduler is a simple RTOS scheduler that does not allow any
+		 * thread to run if a higher-priority thread is runnable.  This means
+		 * that we need a timer interrupt in one of two situations:
+		 *
+		 *  - We have a thread of the same priority as the current thread and
+		 *    we are going to round-robin schedule it.
+		 *  - We have a thread of a higher priority than the current thread
+		 *    that is currently sleeping on a timeout and need it to preempt the
+		 *    current thread when its timeout expires.
+		 *
+		 * We currently over approximate the second condition by making the
+		 * timer fire independent of the priority.  If this is every changed,
+		 * some care must be taken to ensure that dynamic priority propagation
+		 * via priority-inheriting futexes behaves correctly.
+		 *
+		 * This should be called after scheduling has changed the list of
+		 * waiting threads.
+		 */
+		static void update()
 		{
-			++Thread::ticksSinceBoot;
-
-			expiretimers();
-			setnext(TIMERCYCLES_PER_TICK);
+			auto *thread             = Thread::current_get();
+			bool  waitingListIsEmpty = ((Thread::waitingList == nullptr) ||
+                                       (Thread::waitingList->expiryTime == -1));
+			bool  threadHasNoPeers =
+			  (thread == nullptr) || (!thread->has_priority_peers());
+			if (waitingListIsEmpty && threadHasNoPeers)
+			{
+				clear();
+			}
+			else
+			{
+				uint64_t nextTimer = waitingListIsEmpty
+				                       ? time() + TIMERCYCLES_PER_TICK
+				                       : Thread::waitingList->expiryTime;
+				setnext(nextTimer);
+			}
 		}
 
-		private:
+		/**
+		 * Wake any threads that were sleeping until a timeout before the
+		 * current time.  This also wakes yielded threads if there are no
+		 * runnable threads.
+		 *
+		 * This should be called when a timer interrupt fires.
+		 */
 		static void expiretimers()
 		{
+			uint64_t now = time();
+			Thread::ticksSinceBoot =
+			  (now - zeroTickTime) / TIMERCYCLES_PER_TICK;
 			if (Thread::waitingList == nullptr)
 			{
 				return;
 			}
 			for (Thread *iter = Thread::waitingList;;)
 			{
-				if (iter->expiryTime <= Thread::ticksSinceBoot)
+				if (iter->expiryTime <= now)
 				{
 					Thread *iterNext = iter->timerNext;
 
@@ -72,6 +132,39 @@ namespace
 					break;
 				}
 			}
+			// If there are not runnable threads, try to wake a yielded thread
+			if (!Thread::any_ready())
+			{
+				// Look at the first thread.  If it is not yielding, there may
+				// be another thread behind it that is, but that's fine.  We
+				// don't want to encounter situations where (with a
+				// high-priority A and a low-priority B):
+				//
+				// 1. A yields for 5 ticks.
+				// 2. B starts and does a blocking operation (e.g. try_lock)
+				//    with a 1-tick timeout.
+				// 3. A wakes up and prevents B from running even though we're
+				//    still in its 5-tick yield period.
+				if (Thread *head = Thread::waitingList)
+				{
+					if (head->is_yielding())
+					{
+						Debug::log("Woke thread {} {} cycles early",
+						           head->id_get(),
+						           int64_t(head->expiryTime) - now);
+						head->ready(Thread::WakeReason::Timer);
+					}
+				}
+			}
 		}
 	};
+
+	uint64_t expiry_time_for_timeout(uint32_t timeout)
+	{
+		if (timeout == -1)
+		{
+			return -1;
+		}
+		return Timer::time() + (timeout * TIMERCYCLES_PER_TICK);
+	}
 } // namespace

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -970,7 +970,13 @@ __Z13thread_id_getv:
 	// Load the trusted stack pointer into a register that we will clobber in
 	// the next instruction when we load the thread ID.
 	cspecialr          ca0, mtdc
+	cgettag            a1, ca0
+	// If this is a null pointer, don't try to dereference it and report that
+	// we are thread 0.  This permits the debug code to work even from things
+	// that are not real threads.
+	beqz               a1, .Lend
 	clh                a0, TrustedStack_offset_threadID(ca0)
+.Lend:
 	cret
 
 

--- a/sdk/include/FreeRTOS-Compat/task.h
+++ b/sdk/include/FreeRTOS-Compat/task.h
@@ -55,7 +55,7 @@ static inline BaseType_t xTaskCheckForTimeOut(TimeOut_t  *pxTimeOut,
 static inline void vTaskDelay(const TickType_t xTicksToDelay)
 {
 	struct Timeout timeout = {0, xTicksToDelay};
-	thread_sleep(&timeout);
+	thread_sleep(&timeout, ThreadSleepNoEarlyWake);
 }
 
 /**

--- a/sdk/lib/debug/debug.cc
+++ b/sdk/lib/debug/debug.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <debug.hh>
+#include <thread.h>
 
 using namespace CHERI;
 
@@ -335,7 +336,13 @@ debug_log_message_write(const char          *context,
 	DebugPrinter printer;
 	printer.write("\x1b[35m");
 	printer.write(context);
+#if 0
+	printer.write(" [Thread ");
+	printer.write(thread_id_get());
+	printer.write("]\033[0m: ");
+#else
 	printer.write("\033[0m: ");
+#endif
 	printer.format(format, messages, messageCount);
 	printer.write("\n");
 }

--- a/tests/locks-test.cc
+++ b/tests/locks-test.cc
@@ -59,7 +59,9 @@ namespace
 		     "Trying to acquire lock spuriously succeeded");
 		if constexpr (!std::is_same_v<Lock, FlagLockPriorityInherited>)
 		{
+#ifndef SIMULATION
 			TEST(t.elapsed >= 1, "Sleep slept for {} ticks", t.elapsed);
+#endif
 		}
 	}
 


### PR DESCRIPTION
Timers are now not set for a regular tick, they are set when a thread
may be preempted.  Specifically, the timer is set to the next timeout
that will trigger a scheduling operation.  This avoids timers
triggering a switch to the scheduler to do nothing (resume the currently
running thread).

This means that if a thread sleeps for ten ticks while another runs, we
will get one timer interrupt ten ticks in the future, rather than ten
interrupts one tick apart.

This means that ticks are now calculated retroactively based on elapsed
time, rather than counted on each context switch.

This, in turn, necessitates some small API changes.  We previously
conflated two things:

 - Sleep for N * (tick duration)
 - Yield and allow lower-priority threads to run for, at most, N * (tick
   duration)

These are now deconflated by adding a second parameter to thread_sleep.
Most sleeps are of the second form and so this is the default.

This reduces the time taken to run the test suite on Sonata by around 
30% and in the Ibex SAFE simulator by 13%.
