### PR TITLE
Expose the fact that the MAC is not unique.

### DIFF
--- a/sdk/include/platform/arty-a7/platform-ethernet.hh
+++ b/sdk/include/platform/arty-a7/platform-ethernet.hh
@@ -480,9 +480,18 @@ class KunyanEthernet
 	KunyanEthernet(const KunyanEthernet &) = delete;
 	KunyanEthernet(KunyanEthernet &&)      = delete;
 
+	/**
+	 * This device does not have a unique MAC address and so users must provide
+	 * a locally administered MAC address if more than one device is present on
+	 * the same network.
+	 */
+	static constexpr bool has_unique_mac_address()
+	{
+		return false;
+	}
+
 	static constexpr MACAddress mac_address_default()
 	{
-		// FIXME: Generate a random locally administered MAC for each device.
 		return {0x60, 0x6A, 0x6A, 0x37, 0x47, 0x88};
 	}
 

--- a/sdk/include/platform/concepts/ethernet.hh
+++ b/sdk/include/platform/concepts/ethernet.hh
@@ -40,6 +40,14 @@ concept EthernetAdaptor = requires(T                      adaptor,
 		T::mac_address_default()
 		} -> std::same_as<std::array<uint8_t, 6>>;
 	/**
+	 * Is the default MAC address unique?  If the device (e.g. soft MAC)
+	 * doesn't have its own hardware MAC address then callers may prefer to
+	 * generate a locally administered MAC address randomly.
+	 */
+	{
+		T::has_unique_mac_address()
+		} -> std::convertible_to<bool>;
+	/**
 	 * Set the MAC address of this adaptor.
 	 */
 	{adaptor.mac_address_set(macAddress)};


### PR DESCRIPTION
With a single FPGA on a network it was fine to have a single random MAC. With two, we need to be able to determine whether to just use the device's one or generate a random one.