### PR TITLE
Add APIs for checking stack usage.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           - build-type: debug
             build-flags: --debug-loader=y --debug-scheduler=y --debug-allocator=y -m debug
           - build-type: release
-            build-flags: --debug-loader=n --debug-scheduler=n --debug-allocator=n -m release
+            build-flags: --debug-loader=n --debug-scheduler=n --debug-allocator=n -m release --stack-usage-check-allocator=y
       fail-fast: false
     runs-on: ubuntu-latest
     container:

--- a/sdk/core/allocator/alloc_config.h
+++ b/sdk/core/allocator/alloc_config.h
@@ -23,3 +23,16 @@ constexpr size_t MallocAlignShift = 3;
 
 constexpr size_t MallocAlignment = 1U << MallocAlignShift;
 constexpr size_t MallocAlignMask = MallocAlignment - 1;
+
+constexpr StackCheckMode StackMode =
+#if CHERIOT_STACK_CHECKS_ALLOCATOR
+  StackCheckMode::Asserting
+#else
+  StackCheckMode::Disabled
+// Uncomment if checks failed to find the correct values
+// StackCheckMode::Logging
+#endif
+  ;
+
+#define STACK_CHECK(expected)                                                  \
+	StackUsageCheck<StackMode, expected, __PRETTY_FUNCTION__> stackCheck

--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -803,8 +803,10 @@ namespace
 
 } // namespace
 
-size_t heap_quota_remaining(struct SObjStruct *heapCapability)
+__cheriot_minimum_stack(0x80) size_t
+  heap_quota_remaining(struct SObjStruct *heapCapability)
 {
+	STACK_CHECK(0x80);
 	LockGuard g{lock};
 	auto     *cap = malloc_capability_unseal(heapCapability);
 	if (cap == nullptr)
@@ -814,8 +816,9 @@ size_t heap_quota_remaining(struct SObjStruct *heapCapability)
 	return cap->quota;
 }
 
-void heap_quarantine_empty()
+__cheriot_minimum_stack(0xb0) void heap_quarantine_empty()
 {
+	STACK_CHECK(0xb0);
 	LockGuard g{lock};
 	while (gm->heapQuarantineSize > 0)
 	{
@@ -829,8 +832,11 @@ void heap_quarantine_empty()
 	}
 }
 
-void *heap_allocate(Timeout *timeout, SObj heapCapability, size_t bytes)
+__cheriot_minimum_stack(0x1f0) void *heap_allocate(Timeout *timeout,
+                                                   SObj     heapCapability,
+                                                   size_t   bytes)
 {
+	STACK_CHECK(0x1f0);
 	if (!check_timeout_pointer(timeout))
 	{
 		return nullptr;
@@ -850,8 +856,10 @@ void *heap_allocate(Timeout *timeout, SObj heapCapability, size_t bytes)
 	return malloc_internal(bytes, std::move(g), cap, timeout);
 }
 
-size_t heap_claim(SObj heapCapability, void *pointer)
+__cheriot_minimum_stack(0x1b0) size_t
+  heap_claim(SObj heapCapability, void *pointer)
 {
+	STACK_CHECK(0x1b0);
 	LockGuard g{lock};
 	auto     *cap = malloc_capability_unseal(heapCapability);
 	if (cap == nullptr)
@@ -878,14 +886,18 @@ size_t heap_claim(SObj heapCapability, void *pointer)
 	return 0;
 }
 
-int heap_can_free(SObj heapCapability, void *rawPointer)
+__cheriot_minimum_stack(0xe0) int heap_can_free(SObj  heapCapability,
+                                                void *rawPointer)
 {
+	STACK_CHECK(0xe0);
 	LockGuard g{lock};
 	return heap_free_internal(heapCapability, rawPointer, false);
 }
 
-int heap_free(SObj heapCapability, void *rawPointer)
+__cheriot_minimum_stack(0x250) int heap_free(SObj  heapCapability,
+                                             void *rawPointer)
 {
+	STACK_CHECK(0x250);
 	LockGuard g{lock};
 	int       ret = heap_free_internal(heapCapability, rawPointer, true);
 	if (ret != 0)
@@ -904,8 +916,9 @@ int heap_free(SObj heapCapability, void *rawPointer)
 	return 0;
 }
 
-ssize_t heap_free_all(SObj heapCapability)
+__cheriot_minimum_stack(0x180) ssize_t heap_free_all(SObj heapCapability)
 {
+	STACK_CHECK(0x180);
 	LockGuard g{lock};
 	auto     *capability = malloc_capability_unseal(heapCapability);
 	if (capability == nullptr)
@@ -942,11 +955,12 @@ ssize_t heap_free_all(SObj heapCapability)
 	return freed;
 }
 
-void *heap_allocate_array(Timeout *timeout,
-                          SObj     heapCapability,
-                          size_t   nElements,
-                          size_t   elemSize)
+__cheriot_minimum_stack(0x1f0) void *heap_allocate_array(Timeout *timeout,
+                                                         SObj   heapCapability,
+                                                         size_t nElements,
+                                                         size_t elemSize)
 {
+	STACK_CHECK(0x1f0);
 	if (!check_timeout_pointer(timeout))
 	{
 		return nullptr;
@@ -1087,12 +1101,14 @@ SKey token_key_new()
 	return nullptr;
 }
 
-SObj token_sealed_unsealed_alloc(Timeout *timeout,
-                                 SObj     heapCapability,
-                                 SKey     key,
-                                 size_t   sz,
-                                 void   **unsealed)
+__cheriot_minimum_stack(0x250) SObj
+  token_sealed_unsealed_alloc(Timeout *timeout,
+                              SObj     heapCapability,
+                              SKey     key,
+                              size_t   sz,
+                              void   **unsealed)
 {
+	STACK_CHECK(0x250);
 	if (!check_timeout_pointer(timeout))
 	{
 		return INVALID_SOBJ;
@@ -1112,11 +1128,12 @@ SObj token_sealed_unsealed_alloc(Timeout *timeout,
 	return INVALID_SOBJ;
 }
 
-SObj token_sealed_alloc(Timeout *timeout,
-                        SObj     heapCapability,
-                        SKey     rawKey,
-                        size_t   sz)
+__cheriot_minimum_stack(0x250) SObj token_sealed_alloc(Timeout *timeout,
+                                                       SObj     heapCapability,
+                                                       SKey     rawKey,
+                                                       size_t   sz)
 {
+	STACK_CHECK(0x250);
 	return allocate_sealed_unsealed(
 	         timeout, heapCapability, rawKey, sz, {Permission::Seal})
 	  .first;
@@ -1149,8 +1166,11 @@ __noinline static SealedAllocation unseal_internal(SKey rawKey, SObj obj)
 	return unsealed;
 }
 
-int token_obj_destroy(SObj heapCapability, SKey key, SObj object)
+__cheriot_minimum_stack(0x250) int token_obj_destroy(SObj heapCapability,
+                                                     SKey key,
+                                                     SObj object)
 {
+	STACK_CHECK(0x250);
 	void *unsealed;
 	{
 		LockGuard g{lock};
@@ -1168,8 +1188,11 @@ int token_obj_destroy(SObj heapCapability, SKey key, SObj object)
 	return heap_free(heapCapability, unsealed);
 }
 
-int token_obj_can_destroy(SObj heapCapability, SKey key, SObj object)
+__cheriot_minimum_stack(0xe0) int token_obj_can_destroy(SObj heapCapability,
+                                                        SKey key,
+                                                        SObj object)
 {
+	STACK_CHECK(0xe0);
 	void *unsealed;
 	{
 		LockGuard g{lock};

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -952,6 +952,13 @@ __Z13thread_id_getv:
 	cret
 
 
+	.section .text, "ax", @progbits
+	.p2align 2
+	.type __Z25stack_lowest_used_addressv,@function
+__Z25stack_lowest_used_addressv:
+	// Read the stack high-water mark into the return register.
+	csrr               a0, CSR_MSHWM
+	cret
 
 // The linker expects export tables to start with space for cgp and pcc, then
 // the compartment error handler.  We should eventually remove that requirement
@@ -986,3 +993,4 @@ export __Z25switcher_interrupt_threadPv
 export __Z23switcher_current_threadv
 export __Z28switcher_thread_hazard_slotsv
 export __Z13thread_id_getv
+export __Z25stack_lowest_used_addressv

--- a/sdk/include/cdefs.h
+++ b/sdk/include/cdefs.h
@@ -62,6 +62,7 @@ using _Bool = bool;
 #define __alloc_size(x) __attribute__((alloc_size(x)))
 #define __alloc_align(x) __attribute__((alloc_align(x)))
 #define __cheri_callback __attribute__((cheri_ccallback))
+#define __cheriot_minimum_stack(x) __attribute__((cheriot_minimum_stack(x)))
 // When running clang-tidy, we use the same compile flags for everything and so
 // will get errors about things being defined in the wrong compartment, so
 // define away the compartment name and pretend everything is local for now.

--- a/sdk/include/switcher.h
+++ b/sdk/include/switcher.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cdefs.h>
+#include <stddef.h>
 
 /**
  * Returns true if the trusted stack contains at least `requiredFrames` frames
@@ -49,3 +50,9 @@ __cheri_libcall _Bool switcher_interrupt_thread(void *);
  * next cross-compartment call or until they are explicitly overwritten.
  */
 __cheri_libcall void **switcher_thread_hazard_slots(void);
+
+/**
+ * Returns the lowest address that has been stored to on the stack in this
+ * compartment invocation.
+ */
+__cheri_libcall ptraddr_t stack_lowest_used_address(void);

--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -542,7 +542,20 @@ void test_allocator()
 	TEST(heap_address_is_valid(&noWait) == false,
 	     "Global object incorrectly reported as heap address");
 
+	t = 5;
+	Capability array{heap_allocate_array(&t, MALLOC_CAPABILITY, 0x80000004, 2)};
+	TEST(
+	  !array.is_valid(), "Allocating too large an array succeeded: {}", array);
+	array = heap_allocate_array(&t, MALLOC_CAPABILITY, 16, 2);
+	TEST(array.is_valid(), "Allocating array failed: {}", array);
+	TEST(array.length() == 32,
+	     "Allocating array returned incorrect length: {}",
+	     array);
+	ret = heap_free(MALLOC_CAPABILITY, array);
+	TEST(ret == 0, "Freeing array failed: {}", ret);
+
 	test_blocking_allocator();
+	heap_quarantine_empty();
 	test_revoke();
 	test_fuzz();
 	allocations.clear();


### PR DESCRIPTION
This makes it possible to dynamically check the maximum stack usage for a compartment entry point in testing.  This is intended to be used in conjunction with CHERIoT-Platform/llvm-project#22, which makes it possible to specify the minimum stack size (enforced by the switcher).