### PR TITLE
Add stack usage checks for the scheduler.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           - build-type: debug
             build-flags: --debug-loader=y --debug-scheduler=y --debug-allocator=y -m debug
           - build-type: release
-            build-flags: --debug-loader=n --debug-scheduler=n --debug-allocator=n -m release --stack-usage-check-allocator=y
+            build-flags: --debug-loader=n --debug-scheduler=n --debug-allocator=n -m release --stack-usage-check-allocator=y --stack-usage-check-scheduler=y
       fail-fast: false
     runs-on: ubuntu-latest
     container:

--- a/sdk/core/scheduler/common.h
+++ b/sdk/core/scheduler/common.h
@@ -30,6 +30,20 @@ namespace
 	  ;
 
 	using Debug = ConditionalDebug<DebugScheduler, "Scheduler">;
+
+	constexpr StackCheckMode StackMode =
+#if CHERIOT_STACK_CHECKS_SCHEDULER
+	  StackCheckMode::Asserting
+#else
+	  StackCheckMode::Disabled
+	// Uncomment if checks failed to find the correct values
+	// StackCheckMode::Logging
+#endif
+	  ;
+
+#define STACK_CHECK(expected)                                                  \
+	StackUsageCheck<StackMode, expected, __PRETTY_FUNCTION__> stackCheck
+
 	/**
 	 * Base class for types that are exported from the scheduler with a common
 	 * sealing type.  Includes an inline type marker.

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -49,6 +49,7 @@ function stackCheckOption(name)
 end
 
 stackCheckOption("allocator")
+stackCheckOption("scheduler")
 
 -- Force -Oz irrespective of build config.  At -O0, we blow out our stack and
 -- require much stronger alignment.


### PR DESCRIPTION
It should now be impossible to trick the core compartments of the RTOS into exhausting the stack.  It's probably still possible though, because the test suite almost certainly doesn't have sufficient coverage, but this is a start and now we can get failures in other things if we test them with the right build options.