### PR TITLE
Add a `queue_destroy` API.

### DIFF
--- a/sdk/include/queue.h
+++ b/sdk/include/queue.h
@@ -77,6 +77,20 @@ int __cheri_libcall queue_create(Timeout            *timeout,
                                  size_t              elementCount);
 
 /**
+ * Destroys a queue. This wakes up all threads waiting to produce or consume,
+ * and makes them fail to acquire the lock, before deallocating the underlying
+ * allocation.
+ *
+ * This must be called on an unrestricted queue handle (*not* one returned by
+ * `queue_make_receive_handle` or `queue_make_send_handle`).
+ *
+ * Returns 0 on success. On failure, returns `-EPERM` if the queue handle is
+ * restricted (see comment above).
+ */
+int __cheri_libcall queue_destroy(struct SObjStruct  *heapCapability,
+                                  struct QueueHandle *handle);
+
+/**
  * Convert a queue handle returned from `queue_create` into one that can be
  * used *only* for receiving.
  *

--- a/tests/queue-test.cc
+++ b/tests/queue-test.cc
@@ -96,7 +96,7 @@ void test_queue_unsealed()
 	checkSpace(1);
 	queue_receive(&timeout, &queue, bytes);
 	checkSpace(0);
-	rv = heap_free(MALLOC_CAPABILITY, queueMemory);
+	rv = queue_destroy(MALLOC_CAPABILITY, &queue);
 	TEST(rv == 0, "Queue deletion failed with {}", rv);
 	debug_log("All queue library tests successful");
 }


### PR DESCRIPTION
This new API destroys a queue, waking up all threads waiting to produce or consume, and making them fail to acquire the lock, before deallocating the underlying allocation.

This requires to add a destruction mode to the high bits lock class.

This is particularly useful when destroying a message queue from an error handler.