### PR TITLE
Add a `eventgroup_destroy_force` API.

### DIFF
--- a/sdk/include/event.h
+++ b/sdk/include/event.h
@@ -108,3 +108,12 @@ int __cheri_libcall eventgroup_get(struct EventGroup *group, uint32_t *outBits);
  */
 int __cheri_libcall eventgroup_destroy(struct SObjStruct *heapCapability,
                                        struct EventGroup *group);
+
+/**
+ * Destroy an event group without tacking the lock.
+ *
+ * This API is inherently racy. Its main purpose is to cleanup the event group
+ * in an error handler context, when taking lock may be impossible.
+ */
+int __cheri_libcall eventgroup_destroy_force(struct SObjStruct *heapCapability,
+                                             struct EventGroup *group);

--- a/sdk/lib/event_group/event_group.cc
+++ b/sdk/lib/event_group/event_group.cc
@@ -177,9 +177,9 @@ int eventgroup_get(EventGroup *group, uint32_t *outBits)
 	return 0;
 }
 
-int eventgroup_destroy(SObjStruct *heapCapability, EventGroup *group)
+int eventgroup_destroy_force(SObjStruct *heapCapability, EventGroup *group)
 {
-	group->lock.lock();
+	group->lock.upgrade_for_destruction();
 	// Force all waiters to wake.
 	for (size_t i = 0; i < group->waiterCount; ++i)
 	{
@@ -192,4 +192,10 @@ int eventgroup_destroy(SObjStruct *heapCapability, EventGroup *group)
 	}
 	heap_free(heapCapability, group);
 	return 0;
+}
+
+int eventgroup_destroy(SObjStruct *heapCapability, EventGroup *group)
+{
+	group->lock.lock();
+	return eventgroup_destroy_force(heapCapability, group);
 }


### PR DESCRIPTION
This new API destroys an event group without tacking the lock.

This API is inherently racy. Its main purpose is to cleanup the event group in an error handler context, when taking lock may be impossible.

While we are at it, all `eventgroup_destroy` operations, forced or not, should upgrade the lock for destruction before freeing it.

We could also add a `force` parameter to the existing `eventgroup_destroy` API, however we would need to go and edit all callers since this is a C API.