### PR TITLE
Fixed overflows in wait functions

### DIFF
--- a/sdk/include/thread.h
+++ b/sdk/include/thread.h
@@ -91,16 +91,12 @@ static inline uint64_t thread_microsecond_spin(uint32_t microseconds)
 #else
 	static const uint32_t CyclesPerMicrosecond = CPU_TIMER_HZ / 1'000'000;
 	__if_cxx(
-	  static_assert(CyclesPerMicrosecond > 0, "CPU_TIMER_HZ is too low");)
-	  uint64_t start = rdcycle64();
+	  static_assert(CyclesPerMicrosecond > 0, "CPU_TIMER_HZ is too low"););
+	uint64_t start = rdcycle64();
 	// Convert the microseconds to a number of cycles.  This does the multiply
 	// first so that we don't end up with zero as a result of the division.
 	uint32_t cycles = microseconds * CyclesPerMicrosecond;
-#	ifdef X
-	Debug::log("Cycles per us: {}", CyclesPerMicrosecond);
-	Debug::log("Spinning for {} cycles", cycles);
-#	endif
-	uint64_t end = start + cycles;
+	uint64_t end    = start + cycles;
 	uint64_t current;
 	do
 	{
@@ -127,11 +123,9 @@ static inline uint64_t thread_millisecond_wait(uint32_t milliseconds)
 	return milliseconds;
 #else
 	static const uint32_t CyclesPerMillisecond = CPU_TIMER_HZ / 1'000;
+	static const uint32_t CyclesPerTick        = CPU_TIMER_HZ / TICK_RATE_HZ;
 	__if_cxx(
-	  static_assert(
-	    CyclesPerMillisecond > 0,
-	    "CPU_TIMER_HZ is too low");) static const uint32_t CyclesPerTick =
-	  CPU_TIMER_HZ / TICK_RATE_HZ;
+	  static_assert(CyclesPerMillisecond > 0, "CPU_TIMER_HZ is too low"););
 	uint32_t cycles  = milliseconds * CyclesPerMillisecond;
 	uint64_t start   = rdcycle64();
 	uint64_t end     = start + cycles;

--- a/sdk/include/thread.h
+++ b/sdk/include/thread.h
@@ -95,7 +95,7 @@ static inline uint64_t thread_microsecond_spin(uint32_t microseconds)
 	  uint64_t start = rdcycle64();
 	// Convert the microseconds to a number of cycles.  This does the multiply
 	// first so that we don't end up with zero as a result of the division.
-	uint32_t cycles = microseconds / CyclesPerMicrosecond;
+	uint32_t cycles = microseconds * CyclesPerMicrosecond;
 #	ifdef X
 	Debug::log("Cycles per us: {}", CyclesPerMicrosecond);
 	Debug::log("Spinning for {} cycles", cycles);
@@ -106,7 +106,7 @@ static inline uint64_t thread_microsecond_spin(uint32_t microseconds)
 	{
 		current = rdcycle64();
 	} while (current < end);
-	return ((current - start) * CPU_TIMER_HZ) / 1'000'000;
+	return (current - start) * CyclesPerMicrosecond;
 #endif
 }
 
@@ -132,7 +132,7 @@ static inline uint64_t thread_millisecond_wait(uint32_t milliseconds)
 	    CyclesPerMillisecond > 0,
 	    "CPU_TIMER_HZ is too low");) static const uint32_t CyclesPerTick =
 	  CPU_TIMER_HZ / TICK_RATE_HZ;
-	uint32_t cycles  = CPU_TIMER_HZ * milliseconds / 1'000;
+	uint32_t cycles  = milliseconds * CyclesPerMillisecond;
 	uint64_t start   = rdcycle64();
 	uint64_t end     = start + cycles;
 	uint64_t current = start;
@@ -148,7 +148,7 @@ static inline uint64_t thread_millisecond_wait(uint32_t milliseconds)
 		current = rdcycle64();
 	}
 	current = rdcycle64();
-	return ((current - start) * CPU_TIMER_HZ) / 1'000;
+	return (current - start) * CyclesPerMillisecond;
 #endif
 }
 


### PR DESCRIPTION
An overflow in the `thread_millisecond_wait` was likely with 30MHz clocks.

There's an additional commit that removes debug messages and adds semicolons to the end of `__if_cxx` which produces slightly nicer results out of clang-format.