### PR TITLE
Various fixes related to memory allocator error handling

### DIFF
--- a/benchmarks/allocation/alloc.cc
+++ b/benchmarks/allocation/alloc.cc
@@ -31,7 +31,7 @@ void __cheri_compartment("allocbench") run()
 		}
 		auto end = rdcycle();
 		printf(__XSTRING(BOARD) "\t%ld\t%ld\n", static_cast<int>(size), end - start);
-		size_t quota = heap_quota_remaining(MALLOC_CAPABILITY);
+		auto quota = heap_quota_remaining(MALLOC_CAPABILITY);
 		Debug::Invariant(quota == MALLOC_QUOTA, "Quota remaining {}, should be {}", quota, MALLOC_QUOTA);
 		Debug::log("Flushing quarantine");
 		heap_quarantine_empty();

--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -803,7 +803,7 @@ namespace
 
 } // namespace
 
-__cheriot_minimum_stack(0x80) size_t
+__cheriot_minimum_stack(0x80) ssize_t
   heap_quota_remaining(struct SObjStruct *heapCapability)
 {
 	STACK_CHECK(0x80);
@@ -856,7 +856,7 @@ __cheriot_minimum_stack(0x1f0) void *heap_allocate(Timeout *timeout,
 	return malloc_internal(bytes, std::move(g), cap, timeout);
 }
 
-__cheriot_minimum_stack(0x1b0) size_t
+__cheriot_minimum_stack(0x1b0) ssize_t
   heap_claim(SObj heapCapability, void *pointer)
 {
 	STACK_CHECK(0x1b0);

--- a/sdk/core/scheduler/common.h
+++ b/sdk/core/scheduler/common.h
@@ -247,6 +247,10 @@ namespace
 		HeapObject(struct SObjStruct *heapCapability, T *allocatedObject)
 		  : pointer(allocatedObject, heapCapability)
 		{
+			if (!__builtin_cheri_tag_get(allocatedObject))
+			{
+				pointer = nullptr;
+			}
 		}
 
 		/**
@@ -264,9 +268,13 @@ namespace
 		              heap_allocate(timeout, heapCapability, sizeof(T))),
 		            {heapCapability})
 		{
-			if (pointer)
+			if (__builtin_cheri_tag_get(pointer.raw()))
 			{
 				new (pointer.get()) T(std::forward<Args>(args)...);
+			}
+			else
+			{
+				pointer = nullptr;
 			}
 		}
 

--- a/sdk/core/scheduler/multiwait.h
+++ b/sdk/core/scheduler/multiwait.h
@@ -194,7 +194,7 @@ namespace
 			                        heapCapability,
 			                        sizeof(MultiWaiterInternal) +
 			                          (length * sizeof(EventWaiter)));
-			if (q == nullptr)
+			if (!__builtin_cheri_tag_get(q))
 			{
 				error = -ENOMEM;
 				return {};

--- a/sdk/include/microvium/microvium_port.h
+++ b/sdk/include/microvium/microvium_port.h
@@ -298,8 +298,13 @@ static uint16_t crc16(MVM_LONG_PTR_TYPE lp, uint16_t size)
  */
 #define MVM_CONTEXTUAL_MALLOC(size, context)                                   \
 	({                                                                         \
-		Timeout t = {0, 0};                                                    \
-		heap_allocate(&t, context, size);                                      \
+		Timeout t   = {0, 0};                                                  \
+		void   *ret = heap_allocate(&t, context, size);                        \
+		if (!__builtin_cheri_tag_get(ret))                                     \
+		{                                                                      \
+			ret = NULL;                                                        \
+		}                                                                      \
+		ret;                                                                   \
 	})
 #define MVM_CONTEXTUAL_FREE(ptr, context) heap_free(context, ptr)
 

--- a/sdk/include/stdlib.h
+++ b/sdk/include/stdlib.h
@@ -154,7 +154,7 @@ void *__cheri_compartment("alloc")
  * (if `heapCapability` or `pointer` is not valid, etc.), or `-ENOTENOUGHSTACK`
  * if the stack is insufficiently large to run the function.
  */
-size_t __cheri_compartment("alloc")
+ssize_t __cheri_compartment("alloc")
   heap_claim(struct SObjStruct *heapCapability, void *pointer);
 
 /**
@@ -211,7 +211,7 @@ int __cheri_compartment("alloc")
  * `heapCapability` is not valid or if the stack is insufficient to run the
  * function.
  */
-size_t __cheri_compartment("alloc")
+ssize_t __cheri_compartment("alloc")
   heap_quota_remaining(struct SObjStruct *heapCapability);
 
 /**

--- a/sdk/include/stdlib.h
+++ b/sdk/include/stdlib.h
@@ -238,13 +238,23 @@ static inline void __dead2 abort()
 #ifndef CHERIOT_NO_AMBIENT_MALLOC
 static inline void *malloc(size_t size)
 {
-	Timeout t = {0, 0};
-	return heap_allocate(&t, MALLOC_CAPABILITY, size);
+	Timeout t   = {0, 0};
+	void   *ptr = heap_allocate(&t, MALLOC_CAPABILITY, size);
+	if (!__builtin_cheri_tag_get(ptr))
+	{
+		ptr = NULL;
+	}
+	return ptr;
 }
 static inline void *calloc(size_t nmemb, size_t size)
 {
-	Timeout t = {0, 0};
-	return heap_allocate_array(&t, MALLOC_CAPABILITY, nmemb, size);
+	Timeout t   = {0, 0};
+	void   *ptr = heap_allocate_array(&t, MALLOC_CAPABILITY, nmemb, size);
+	if (!__builtin_cheri_tag_get(ptr))
+	{
+		ptr = NULL;
+	}
+	return ptr;
 }
 static inline int free(void *ptr)
 {

--- a/sdk/lib/event_group/event_group.cc
+++ b/sdk/lib/event_group/event_group.cc
@@ -46,7 +46,7 @@ int eventgroup_create(Timeout     *timeout,
 	auto   group =
 	  static_cast<EventGroup *>(heap_allocate(timeout, heapCapability, size));
 	*outGroup = group;
-	if (!group)
+	if (!__builtin_cheri_tag_get(group))
 	{
 		return -ENOMEM;
 	}

--- a/sdk/lib/queue/queue_compartment.cc
+++ b/sdk/lib/queue/queue_compartment.cc
@@ -78,6 +78,7 @@ int queue_create_sealed(Timeout            *timeout,
 	receive->allocation = freeBuffer;
 	// Add a second claim on the buffer so that we can free the queue by freeing
 	// it twice, once in each endpoint.
+	// TODO we should check the return value of `heap_claim`
 	heap_claim(heapCapability, freeBuffer);
 
 	if (int claimed = heap_claim_fast(timeout, outQueueSend, outQueueReceive);

--- a/tests/queue-test.cc
+++ b/tests/queue-test.cc
@@ -104,7 +104,7 @@ void test_queue_unsealed()
 
 void test_queue_sealed()
 {
-	size_t  heapSpace = heap_quota_remaining(MALLOC_CAPABILITY);
+	auto    heapSpace = heap_quota_remaining(MALLOC_CAPABILITY);
 	Timeout t{1};
 	SObj    receiveHandle;
 	SObj    sendHandle;


### PR DESCRIPTION
We have recently introduced strong stack size requirements in the allocator (https://github.com/microsoft/cheriot-rtos/pull/205). Following this, `-ECOMPARTMENTFAIL` is returned not only when the allocator compartment crashes, but also at compartment entry when the stack is insufficient to proceed safely.

Entering a state where the stack is not sufficient to call the allocator is not unrealistic given that we are running with very small stacks. We need to handle it well.

Unfortunately this behavior has not yet been documented, and the code has not been adapted to it. Nearly the entire core repository still does `NULL` pointer checks to check the return value of a memory allocation.

This commit documents this new behavior at appropriate places and fixes allocator call sites to ensure that the valid bit is checked instead of a comparison with a `NULL` pointer.