### PR TITLE
stdlib `malloc` should not block indefinitely.

### DIFF
--- a/sdk/include/stdlib.h
+++ b/sdk/include/stdlib.h
@@ -238,12 +238,12 @@ static inline void __dead2 abort()
 #ifndef CHERIOT_NO_AMBIENT_MALLOC
 static inline void *malloc(size_t size)
 {
-	Timeout t = {0, UnlimitedTimeout};
+	Timeout t = {0, 0};
 	return heap_allocate(&t, MALLOC_CAPABILITY, size);
 }
 static inline void *calloc(size_t nmemb, size_t size)
 {
-	Timeout t = {0, UnlimitedTimeout};
+	Timeout t = {0, 0};
 	return heap_allocate_array(&t, MALLOC_CAPABILITY, nmemb, size);
 }
 static inline int free(void *ptr)


### PR DESCRIPTION
Currently `malloc` blocks indefinitely when it cannot perform an allocation. This deviates from the usual behavior of `malloc`, which would return a NULL pointer and may set `errno`, but not block indefinitely, when an allocation cannot be performed.

Set the timeout to 0 to immediately return when an allocation cannot be satisfied.