### PR TITLE
Add missing stack check.

### DIFF
--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -3,6 +3,7 @@
 
 #include "export-table-assembly.h"
 #include "trusted-stack-assembly.h"
+#include <errno.h>
 
 .include "assembly-helpers.s"
 
@@ -246,6 +247,17 @@ after_zero:
 	// table pointer.  Nothing between this point and transition to the callee
 	// should fault.
 	csc                ct1, TrustedStackFrame_offset_calleeExportTable(ctp)
+
+	// Load the minimum stack size required by the callee.
+	clbu               tp, ExportEntry_offset_minimumStackSize(ct1)
+	// The stack size is in 8-byte units, so multiply by 8.
+	slli               tp, tp, 3
+	// Check that the stack is large enough for the callee.
+	// At this point, we have already truncated the stack and so the length of
+	// the stack is the length that the callee can use.
+	cgetlen            t2, csp
+	bgtu               tp, t2, .Lstack_too_small
+
 	// Get the flags field into tp
 	clbu               tp, ExportEntry_offset_flags(ct1)
 	cgetbase           s1, ct1
@@ -289,6 +301,7 @@ after_zero:
 	zeroRegisters      tp, t1, t2, s0, s1
 	cjalr              cra
 
+.Lskip_compartment_call:
 	// If we are doing a forced unwind of the trusted stack then we do almost
 	// exactly the same as a normal unwind.  We will jump here from the
 	// exception path.
@@ -302,6 +315,15 @@ after_zero:
 	// ca1, used for second return value
 	zeroAllRegistersExcept ra, sp, gp, s0, s1, a0, a1
 	cret
+
+	// If the stack is too small, we don't do the call, but to avoid leaking
+	// any other state we still go through the same return path as normal.  We
+	// set the return registers to -ENOTENOUGHSTACK and 0, so users can see
+	// that this is the failure reason.
+.Lstack_too_small:
+	li                 a0, -ENOTENOUGHSTACK
+	li                 a1, 0
+	j                  .Lskip_compartment_call
 .size compartment_switcher_entry, . - compartment_switcher_entry
 
 	// the entry point of all exceptions and interrupts

--- a/sdk/include/errno.h
+++ b/sdk/include/errno.h
@@ -84,6 +84,7 @@
 #define EOWNERDEAD 130     // Previous owner died.
 #define ENOTRECOVERABLE 131 // State not recoverable.
 #define EOVERFLOW 139       // Value too large to be stored in data type.
+#define ENOTENOUGHSTACK 140 // Insufficient stack space for cross-compartment call.
 #define EWOULDBLOCK EAGAIN  // Operation would block.
 #define ENOTSUP EOPNOTSUPP  // Not supported.
 #define __ELASTERROR 2000   // Users can add values starting here.

--- a/tests/stack_integrity_thread.cc
+++ b/tests/stack_integrity_thread.cc
@@ -139,3 +139,8 @@ void exhaust_trusted_stack(__cheri_callback void (*fn)(),
 {
 	self_recursion(fn);
 }
+
+int test_stack_requirement()
+{
+	return 0;
+}

--- a/tests/stack_tests.h
+++ b/tests/stack_tests.h
@@ -52,3 +52,6 @@ bool holds_switcher_capability(ErrorState *frame)
 
 	return false;
 }
+
+__cheri_compartment("stack_integrity_thread")
+  __cheriot_minimum_stack(128) int test_stack_requirement();

--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -52,6 +52,9 @@ compartment_error_handler(struct ErrorState *frame, size_t mcause, size_t mtval)
 #endif
 		return ErrorRecoveryBehaviour::ForceUnwind;
 	}
+	debug_log("mcause: {}, pcc: {}", mcause, frame->pcc);
+	auto [reg, cause] = CHERI::extract_cheri_mtval(mtval);
+	debug_log("Error {} in register {}", reg, cause);
 	debug_log("Current test crashed");
 	crashDetected = true;
 	return ErrorRecoveryBehaviour::InstallContext;


### PR DESCRIPTION
The ABI has included space for the required stack space from the start, but we only recently started putting anything sensible there.  It turns out that the switcher was missing this check.

This introduces a new errno code to let the caller differentiate between a call that wasn't allowed to proceed and one that crashed.  We may want to use this code for other stack badness.