### PR TITLE
Fix Sonata's memory layout.

### DIFF
--- a/sdk/boards/sonata.json
+++ b/sdk/boards/sonata.json
@@ -28,6 +28,7 @@
     "heap": {
         "end": 0x00140000
     },
+    "revokable_memory_start": 0x00100000,
     "interrupts": [
         {
             "name": "UartRxWatermark",


### PR DESCRIPTION
Sonata starts the revokable memory range (the range that the shadow memory covers) 0x80 bytes before the start of code memory, but the board description file did not mention this.