### PR TITLE
Changed the Sonata instruction memory start

### DIFF
--- a/sdk/boards/sonata.json
+++ b/sdk/boards/sonata.json
@@ -22,7 +22,7 @@
         }
     },
     "instruction_memory": {
-        "start": 0x00100080,
+        "start": 0x00101000,
         "end":   0x00140000
     },
     "heap": {


### PR DESCRIPTION
There is now a bootloader on that sonata platform that loads software to 0x00101000.