### PR TITLE
Sonata has the stack high-water mark register.

### DIFF
--- a/sdk/boards/sonata.json
+++ b/sdk/boards/sonata.json
@@ -50,6 +50,7 @@
     "timer_hz" : 30000000,
     "tickrate_hz" : 100,
     "revoker" : "software",
+    "stack_high_water_mark" : true,
     "simulator" : "${sdk}/../scripts/run-sonata.sh",
     "simulation": false
 }


### PR DESCRIPTION
For some reason, this was not enabled in the Sonata board config. Enabling it improves the test suite performance by around 5%.