### PR TITLE
Add missing test file.

### DIFF
--- a/tests/ccompile-freertos-test.c
+++ b/tests/ccompile-freertos-test.c
@@ -1,0 +1,12 @@
+#include <FreeRTOS-Compat/FreeRTOS.h>
+
+#if (CHERIOT_FREERTOS_SEMAPHORE + CHERIOT_FREERTOS_MUTEX +                     \
+      CHERIOT_FREERTOS_RECURSIVE_MUTEX) == 1
+#if CHERIOT_FREERTOS_SEMAPHORE == 1
+_Static_assert(sizeof(StaticSemaphore_t) == sizeof(struct CountingSemaphoreState);
+#elif CHERIOT_FREERTOS_MUTEX == 1
+_Static_assert(sizeof(StaticSemaphore_t) == sizeof(struct FlagLockState));
+#else
+_Static_assert(sizeof(StaticSemaphore_t) == sizeof(struct RecursiveMutexState));
+#endif
+#endif


### PR DESCRIPTION
We have had the build infrastructure for testing that the FreeRTOS headers compile in C mode for a while, but I forgot to add the .c file for the test.