### PR TITLE
Fix corner case in tickless scheduling.

### DIFF
--- a/sdk/core/scheduler/timer.h
+++ b/sdk/core/scheduler/timer.h
@@ -90,10 +90,15 @@ namespace
 			}
 			else
 			{
+				static constexpr uint64_t DistantFuture =
+				  std::numeric_limits<uint64_t>::max();
+				uint64_t nextTick  = threadHasNoPeers
+				                       ? DistantFuture
+				                       : time() + TIMERCYCLES_PER_TICK;
 				uint64_t nextTimer = waitingListIsEmpty
-				                       ? time() + TIMERCYCLES_PER_TICK
+				                       ? DistantFuture
 				                       : Thread::waitingList->expiryTime;
-				setnext(nextTimer);
+				setnext(std::min(nextTick, nextTimer));
 			}
 		}
 


### PR DESCRIPTION
There are two reasons we request a timer interrupt:

 - There is a peer at the same scheduler priority.
 - There is a timer that will expire.

If *both* of these were true, we were delaying the scheduling until the second condition.