### PR TITLE
Add an API to control the blocking behavior of the allocator at a finer grain

### DIFF
--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -303,8 +303,10 @@ namespace
 			}
 			// If the heap is full, wait for someone to free an allocation and
 			// then retry.
-			if (std::holds_alternative<
-			      MState::AllocationFailureDeallocationNeeded>(ret))
+			if (std::holds_alternative<MState::AllocationFailureHeapFull>(
+			      ret) ||
+			    std::holds_alternative<MState::AllocationFailureQuotaExceeded>(
+			      ret))
 			{
 				Debug::log("Not enough free space to handle {}-byte "
 				           "allocation, sleeping",

--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -452,7 +452,7 @@ __cheriot_minimum_stack(0x80) int __cheri_compartment("sched")
 __cheriot_minimum_stack(0xa0) int futex_timed_wait(Timeout        *timeout,
                                                    const uint32_t *address,
                                                    uint32_t        expected,
-                                                   FutexWaitFlags  flags)
+                                                   uint32_t        flags)
 {
 	STACK_CHECK(0xa0);
 	if (!check_timeout_pointer(timeout) ||

--- a/sdk/include/futex.h
+++ b/sdk/include/futex.h
@@ -14,7 +14,7 @@ enum [[clang::flag_enum]] FutexWaitFlags{
    * are assumed to hold the thread ID of the thread that currently holds the
    * lock.
    */
-  FutexPriorityInheritance};
+  FutexPriorityInheritance = (1 << 0)};
 
 /**
  * Compare the value at `address` to `expected` and, if they match, sleep the
@@ -37,10 +37,10 @@ enum [[clang::flag_enum]] FutexWaitFlags{
  *  - `-ETIMEOUT` if the timeout expires.
  */
 [[cheri::interrupt_state(disabled)]] int __cheri_compartment("sched")
-  futex_timed_wait(Timeout                  *ticks,
-                   const uint32_t           *address,
-                   uint32_t                  expected,
-                   enum FutexWaitFlags flags __if_cxx(= FutexNone));
+  futex_timed_wait(Timeout        *ticks,
+                   const uint32_t *address,
+                   uint32_t        expected,
+                   uint32_t flags  __if_cxx(= FutexNone));
 
 /**
  * Compare the value at `address` to `expected` and, if they match, sleep the

--- a/sdk/include/microvium/microvium_port.h
+++ b/sdk/include/microvium/microvium_port.h
@@ -295,11 +295,15 @@ static uint16_t crc16(MVM_LONG_PTR_TYPE lp, uint16_t size)
  *
  * The `context` passed to these macros is whatever value that the host passes
  * to `mvm_restore`. It can be any value that fits in a pointer.
+ *
+ * Similarly to `malloc` and `calloc`, this will only ever
+ * block to wait for the quarantine to be processed.
  */
 #define MVM_CONTEXTUAL_MALLOC(size, context)                                   \
 	({                                                                         \
-		Timeout t   = {0, 0};                                                  \
-		void   *ret = heap_allocate(&t, context, size);                        \
+		Timeout t = {0, MALLOC_WAIT_TICKS};                                    \
+		void   *ret =                                                          \
+		  heap_allocate(&t, context, size, AllocateWaitRevocationNeeded);      \
 		if (!__builtin_cheri_tag_get(ret))                                     \
 		{                                                                      \
 			ret = NULL;                                                        \


### PR DESCRIPTION
The current `timeout` argument of `heap_allocate*` functions determines whether or not and how long the allocator should block for an allocation to be fulfiled. However it does not control on what events the allocator should block.

Currently the allocator would block for three reasons: 1) there is no heap space available anymore, 2) the quota is exhausted, and 3) the quarantine is holding back memory which could be used for the allocation.

For `malloc` and `calloc`, we only want to wait on the quarantine. Thus, we need a finer way to control this blocking behavior.

This PR implements an API to do this, and uses it for `malloc` and `calloc`.

While we are at it, it does a little bit of cleanup in futex which has similar code with `flags`, but got it wrong.