### PR TITLE
Fix `__builtin_strlen`

### DIFF
--- a/sdk/include/cdefs.h
+++ b/sdk/include/cdefs.h
@@ -107,4 +107,12 @@ using _Bool = bool;
 #	define __clang_ignored_warning_pop()
 #endif
 
+/**
+ * Define the symbol for the libcall that the compiler will expand the `strlen`
+ * builtin to.  This builtin is used internally in libc++ (and possibly in
+ * other places) to avoid the namespace pollution from including `string.h` but
+ * is either constant folded in the front end or expanded to a libcall.
+ */
+unsigned __builtin_strlen(const char *str) __asm__("_Z6strlenPKc");
+
 #endif // _CDEFS_H_

--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -105,6 +105,8 @@ void __cheri_compartment("test_runner") run_tests()
 	const char *testString = "Hello, world! with some trailing characters";
 	// Make sure that we don't print the trailing characters
 	debug_log("Trying to print string: {}", std::string_view{testString, 13});
+	std::string hi = "Hello world";
+	debug_log("Trying to print std::string: {}", hi.c_str());
 
 	run_timed("All tests", []() {
 		run_timed("Debug helpers (C++)", test_debug_cxx);


### PR DESCRIPTION
This is the other half of CHERIoT-Platform/llvm-project#29

The compiler will now use the correct calling convention for `__builtin_strlen`, but does not know how to generate it as a mangled name.  We do this by hand to avoid adding more complexity to the compiler for a special case.