### PR TITLE
Add TEST_EQUAL macro in tests.hh.

### DIFF
--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -92,8 +92,9 @@ void __cheri_compartment("test_runner") run_tests()
 	size_t index = 0;
 	for (auto permission : Permissions)
 	{
-		TEST(permission == permissionArray[index++],
-		     "Iterator of PermissionSet failed");
+		TEST_EQUAL(permission,
+		           permissionArray[index++],
+		           "Iterator of PermissionSet failed");
 	}
 	// These need to be checked visually
 	debug_log("Trying to print 8-bit integer: {}", uint8_t(0x12));

--- a/tests/tests.hh
+++ b/tests/tests.hh
@@ -42,6 +42,12 @@ void debug_log(const char *fmt, Args... args)
 }
 
 #define TEST(cond, msg, ...) Test::Invariant((cond), msg, ##__VA_ARGS__)
+#define TEST_EQUAL(e1, e2, msg)                                                \
+	{                                                                          \
+		auto v1 = e1;                                                          \
+		auto v2 = e2;                                                          \
+		Test::Invariant(v1 == v2, "{}: {} != {}", msg, v1, v2);                \
+	}
 
 /**
  * Helper to sleep for a number of ticks and not report the sleep time.


### PR DESCRIPTION
This is improves on TEST as it automatically prints the expected and actual values.  A quick grep indicates about 200 places in the test suite this could be used.