### PR TITLE
Weird Tag violation issue - not to be merged

### DIFF
--- a/examples/10a.odd_error/config_broker.cc
+++ b/examples/10a.odd_error/config_broker.cc
@@ -1,0 +1,284 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+// Contributed by Configured Things Ltd
+
+#include "cdefs.h"
+#include "cheri.hh"
+#include <compartment.h>
+#include <cstdlib>
+#include <debug.hh>
+//#include <fail-simulator-on-error.h>
+#include <futex.h>
+#include <thread.h>
+
+#include <string.h>
+#include <vector>
+
+#include "config_broker.h"
+
+// Import some useful things from the CHERI namespace.
+using namespace CHERI;
+
+// Expose debugging features unconditionally for this compartment.
+//using Debug = ConditionalDebug<DEBUG_CONFIG_BROKER, "Config Broker">;
+using Debug = ConditionalDebug<true, "Config Broker">;
+
+//
+// count of un-sent updates; used as a futex
+//
+static uint32_t pending = 0;
+
+//
+// Set of config data items.
+//
+std::vector<struct ConfigItem *> configData;
+
+using namespace CHERI;
+
+extern "C" ErrorRecoveryBehaviour
+compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval)
+{
+	auto [exceptionCode, registerNumber] = extract_cheri_mtval(mtval);
+	void *faultingRegister               = nullptr;
+	if (registerNumber == RegisterNumber::PCC)
+	{
+		faultingRegister = frame->pcc;
+	}
+	else if ((registerNumber > RegisterNumber::CZR) &&
+	         (registerNumber <= RegisterNumber::CA5))
+	{
+		// The registers array does not include cnull.
+		faultingRegister = frame->registers[int(registerNumber) - 1];
+	}
+	// Make sure that we have a new line before the debug output.
+	// This uses the UART driver directly to write a single byte.
+	MMIO_CAPABILITY(Uart, uart)->blocking_write('\n');
+
+	Debug::log("Detected {} in Conifg Broker.  Register {} contained "
+	           "invalid value: {}",
+	           exceptionCode,
+	           registerNumber,
+	           faultingRegister);
+	return ErrorRecoveryBehaviour::ForceUnwind;
+}
+//
+// unseal a config capability.
+//
+ConfigToken *config_capability_unseal(SObj sealedCap)
+{
+	auto key = STATIC_SEALING_TYPE(ConfigKey);
+
+	ConfigToken *token =
+	  token_unseal<ConfigToken>(key, Sealed<ConfigToken>{sealedCap});
+
+	if (token == nullptr)
+	{
+		Debug::log("invalid config capability {}", sealedCap);
+		return nullptr;
+	}
+
+	Debug::log("Unsealed id: {} kind: {} size:{} item: {}",
+	           token->id,
+	           token->kind,
+	           token->maxSize,
+	           token->configId);
+
+	if (token->id == 0)
+	{
+		// Assign an ID so we can track the callbacks added
+		// from this capability
+		static uint16_t nextId = 1;
+		token->id              = nextId++;
+	}
+
+	return token;
+}
+
+//
+// Find a Config by name.  If it doesn't already exist
+// create one.
+//
+ConfigItem *find_or_create_config(const char *name)
+{
+	for (auto &c : configData)
+	{
+		if (strcmp(c->name, name) == 0)
+		{
+			Debug::log("Found it");
+			return c;
+		}
+	}
+
+	// Allocate a Config object
+	ConfigItem *c = static_cast<ConfigItem *>(malloc(sizeof(ConfigItem)));
+	Debug::log("Created {} {}", name, c);
+
+	// Save the name
+	c->name = static_cast<char *>(malloc(strlen(name)));
+	strncpy(c->name, name, strlen(name));
+	Debug::log("Name copied");
+	//CHERI::Capability(c->name).permissions() &=
+	//  {CHERI::Permission::Load};
+
+	c->version = 0;
+	c->data    = nullptr;
+
+	// Add it to the vector
+	Debug::log("Adding to vector {}", c);
+	configData.push_back(c);
+
+	Debug::log("returning {}", c);
+	return c;
+};
+
+
+//
+// Set a new value for the configuration item described by
+// the capability.
+//
+int __cheri_compartment("config_broker")
+  set_config(SObj sealedCap, void *data, size_t size)
+{
+	ConfigToken *token = config_capability_unseal(sealedCap);
+	if (token == nullptr)
+	{
+		Debug::log("Invalid capability: {}", sealedCap);
+		return -1;
+	}
+
+	// Check we have a WriteToken
+	if (token->kind != WriteToken)
+	{
+		Debug::log(
+		  "Not a write capability for {}: {}", token->configId, sealedCap);
+		return -1;
+	}
+
+	// Check the size and data are consistent with the token
+	// and each other.
+	if (size > token->maxSize)
+	{
+		Debug::log("invalid size {} for capability: {}", size, sealedCap);
+		return -1;
+	}
+
+	if (size > static_cast<size_t>(Capability{data}.bounds()))
+	{
+		Debug::log("size {} > data.bounds() {}", size, data);
+		return -1;
+	}
+
+	// Find or create a config structure
+	ConfigItem *c = find_or_create_config(token->configId);
+
+	// Allocate heap space for the new value
+	void *newData = malloc(size);
+	if (newData == nullptr)
+	{
+		Debug::log("Failed to allocate space for {}", token->configId);
+		return -1;
+	}
+
+	// If we were paranoid about the incomming data we could make this
+	// something that we call into a separate compartment to do 
+	memcpy(newData, data, size);
+
+	// Free the old data value.  Any subscribers that received it should
+	// have thier own claim on it if needed
+	if (c->data)
+	{
+		free(c->data);
+	}
+
+	// Neither we nor the subscribers need to be able to update the
+	// value, so just track through a readOnly capabaility
+	c->data = newData;
+	CHERI::Capability(c->data).permissions() &=
+	  {CHERI::Permission::Load, CHERI::Permission::Global};
+
+	// Mark it as having been updated
+	c->version++;
+
+	// Trigger out thread to process the update 
+	futex_wake(&c->version, -1);
+
+	return 0;
+}
+
+//
+// Get the current value of a Configuration item.  The data
+// member will be nullptr if the item has not yet been set. 
+// The version member can be used as a futex to wait for changes.
+//
+ConfigItem *__cheri_compartment("config_broker")
+  get_config(SObj sealedCap)
+{
+	// Get the calling compartments name from
+	// its sealed capability
+	ConfigToken *token = config_capability_unseal(sealedCap);
+
+	if (token == nullptr)
+	{
+		Debug::log("Invalid capability {}", sealedCap);
+		return nullptr;
+	}
+
+	Debug::log("thread {} on_config called for {} by id {}",
+	           thread_id_get(),
+	           static_cast<const char *>(token->configId),
+	           token->id);
+
+	auto c = find_or_create_config(token->configId);
+	Debug::log("Created");
+
+	// return a read only copy of the item;
+	auto item = c;
+	CHERI::Capability(item).permissions() &=
+	  {CHERI::Permission::Load, CHERI::Permission::Global};
+	return item;
+}
+
+/*
+//
+// thread enrty point
+//
+void __cheri_compartment("config_broker") init()
+{
+	while (true)
+	{
+		// wait for updates
+		futex_wait(&pending, 0);
+		Debug::log("thread {} processing {} updates", thread_id_get(), pending);
+
+		pending = 0;
+
+		// Procces any the modified config data
+		//
+		// Two timing considerations for events that could
+		// occur whilst were making the callbacks
+		//
+		// - If a new callback is registered they get called
+		//   directly, so they might get called twice, which is OK
+		//
+		// - If a new data value is suppled then the rest of the
+		//   callbacks will be called with the new value. The item
+		//   will be tagged as updated and pending incremented so
+		//   we also pick it up on the next loop. Some callbacks
+		//   might be called twice with the same value, which is OK.
+		//
+		for (auto &c : configData)
+		{
+			if (c->updated)
+			{
+				c->updated = false;
+				// Call all the callbacks
+				for (auto &cbInfo : c->cbList)
+				{
+					cbInfo->cb(c->name, c->data);
+				}
+			}
+		}
+	}
+}
+*/

--- a/examples/10a.odd_error/config_broker.h
+++ b/examples/10a.odd_error/config_broker.h
@@ -1,0 +1,91 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+// Contributed by Configured Things Ltd
+
+#include "cdefs.h"
+#include "compartment-macros.h"
+#include "token.h"
+#include <compartment.h>
+
+
+enum ConfigTokenKind
+{
+	ReadToken,
+	WriteToken
+};
+
+struct ConfigToken
+{
+	ConfigTokenKind kind;       // Set to true in write capabilites
+	uint16_t        id;         // id for the capability, assigned on first use
+	size_t          maxSize;    // Max size of the item
+	const char      configId[]; // Name of the configuration item
+};
+
+#define DEFINE_READ_CONFIG_CAPABILITY(name)                                    \
+                                                                               \
+	DECLARE_AND_DEFINE_STATIC_SEALED_VALUE(                                    \
+	  struct {                                                                 \
+		  ConfigTokenKind kind;                                                \
+		  uint16_t        id;                                                  \
+		  size_t          maxSize;                                             \
+		  const char      configId[sizeof(name)];                              \
+	  },                                                                       \
+	  config_broker,                                                           \
+	  ConfigKey,                                                               \
+	  __read_config_capability_##name,                                         \
+	  ReadToken,                                                               \
+	  0,                                                                       \
+	  0,                                                                       \
+	  name);
+
+#define READ_CONFIG_CAPABILITY(name)                                           \
+	STATIC_SEALED_VALUE(__read_config_capability_##name)
+
+#define DEFINE_WRITE_CONFIG_CAPABILITY(name, size)                             \
+                                                                               \
+	DECLARE_AND_DEFINE_STATIC_SEALED_VALUE(                                    \
+	  struct {                                                                 \
+		  ConfigTokenKind kind;                                                \
+		  uint16_t        id;                                                  \
+		  size_t          maxSize;                                             \
+		  const char      configId[sizeof(name)];                              \
+	  },                                                                       \
+	  config_broker,                                                           \
+	  ConfigKey,                                                               \
+	  __write_config_capability_##name,                                        \
+	  WriteToken,                                                              \
+	  0,                                                                       \
+	  size,                                                                    \
+	  name);
+
+#define WRITE_CONFIG_CAPABILITY(name)                                          \
+	STATIC_SEALED_VALUE(__write_config_capability_##name)
+
+//
+// Data type for a configuration item.  The version is used
+// as a futex when waitign for updates
+//
+struct ConfigItem
+{
+	char                        *name;
+	uint32_t                    version;
+	void                        *data;
+};
+
+
+/**
+ * Set configuration data
+ */
+int __cheri_compartment("config_broker")
+  set_config(SObj configWriteCapability, void *data, size_t size);
+
+/**
+ * Register a callback to get notification of configuration
+ * changes.
+ */
+ConfigItem *__cheri_compartment("config_broker")
+  get_config(SObj configReadCapability);
+
+

--- a/examples/10a.odd_error/data.h
+++ b/examples/10a.odd_error/data.h
@@ -1,0 +1,36 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+// Contributed by Configured Things Ltd
+
+#include <debug.hh>
+#include <thread.h>
+
+// In this example for simplicity all configuration
+// items have the same data structure.  In a real
+// system they would be different stuctures each
+// with their own validators
+struct Data
+{
+	uint32_t count;
+	uint32_t padding;
+	char     token[16];
+};
+
+// Helper fucntion for the example to print a config item
+static inline void print_config(const char *why, const char *name, Data *d)
+{
+	if (d == nullptr)
+	{
+		Debug::log("thread {} {} {} -- No config yet", thread_id_get(), why, name);
+	}
+	else
+	{
+		Debug::log("thread {} {} {} -- config count: {} token: {}",
+		           thread_id_get(),
+		           why,
+		           name,
+		           d->count,
+		           static_cast<const char *>(d->token));
+	}
+}

--- a/examples/10a.odd_error/sleep.h
+++ b/examples/10a.odd_error/sleep.h
@@ -1,0 +1,13 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+// Contributed by Configured Things Ltd
+
+#include <thread.h>
+#include <tick_macros.h>
+
+static inline void sleep(const uint32_t mS)
+{
+	Timeout t1{MS_TO_TICKS(mS)};
+	thread_sleep(&t1, ThreadSleepNoEarlyWake);
+}

--- a/examples/10a.odd_error/subscriber1.cc
+++ b/examples/10a.odd_error/subscriber1.cc
@@ -34,7 +34,7 @@ void __cheri_callback update(const char *id, void *data)
 	// to get_config() in init() below, but this callback isn't
 	// used or referenced anymore !
 
-	//print_config("Update", id, config);
+	print_config("Update", id, config);
 }
 
 

--- a/examples/10a.odd_error/subscriber1.cc
+++ b/examples/10a.odd_error/subscriber1.cc
@@ -1,0 +1,58 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+// Contributed by Configured Things Ltd
+
+#include <compartment.h>
+#include <debug.hh>
+#include <fail-simulator-on-error.h>
+#include <thread.h>
+
+// Define a sealed capability that gives this compartment
+// read access to configuration data "config1"
+#include "config_broker.h"
+
+#define CONFIG1 "config1"
+DEFINE_READ_CONFIG_CAPABILITY(CONFIG1)
+
+// Expose debugging features unconditionally for this compartment.
+using Debug = ConditionalDebug<true, "Subscriber #1">;
+
+#include "data.h"
+#include "sleep.h"
+
+// Local pointer to the most recent config value;
+Data *config = nullptr;
+
+//
+// Callback to handle config updates
+//
+void __cheri_callback update(const char *id, void *data)
+{
+	// Commeting out the following line causes a tag violation
+	// to be generated in the config broker as during the call
+	// to get_config() in init() below, but this callback isn't
+	// used or referenced anymore !
+
+	//print_config("Update", id, config);
+}
+
+
+//
+// Thread entry point.
+//
+void __cheri_compartment("subscriber1") init()
+{
+	// Register to get config updates
+	Debug::log("thread {} Register for config updates", thread_id_get());
+	auto c = get_config(READ_CONFIG_CAPABILITY(CONFIG1));
+	Debug::log("thread {} got {}", thread_id_get(), c);
+	
+	// Loop printing our config value occasionally
+	while (true)
+	{
+		sleep(4500);
+		print_config("Timer ", "config1", config);
+	}
+	
+}

--- a/examples/10a.odd_error/xmake.lua
+++ b/examples/10a.odd_error/xmake.lua
@@ -1,0 +1,49 @@
+-- Copyright Microsoft and CHERIoT Contributors.
+-- SPDX-License-Identifier: MIT
+
+-- Contributed by Configured Things Ltd
+
+set_project("CHERIoT Compartmentalised Config")
+sdkdir = "../../sdk"
+includes(sdkdir)
+set_toolchains("cheriot-clang")
+
+-- Support libraries
+includes(path.join(sdkdir, "lib"))
+
+option("board")
+    set_default("ibex-safe-simulator")
+
+-- Configuration Broker
+debugOption("config_broker");
+compartment("config_broker")
+    add_rules("cheriot.component-debug")
+    add_files("config_broker.cc")
+
+-- Compartments to be configured
+compartment("subscriber1")
+    add_files("subscriber1.cc")
+
+-- Debug options
+debugOption("config_broker")
+
+-- Firmware image for the example.
+firmware("compartment_config")
+    -- Both compartments require memcpy
+    add_deps("freestanding", "debug")
+    add_deps("config_broker")
+    add_deps("subscriber1")
+    add_deps("string")
+    on_load(function(target)
+        target:values_set("board", "$(board)")
+        target:values_set("threads", {
+            {
+                compartment = "subscriber1",
+                priority = 3,
+                entry_point = "init",
+                stack_size = 0x400,
+                trusted_stack_frames = 4
+            },
+            
+        }, {expand = false})
+    end)


### PR DESCRIPTION
Hi Folks,

In reworking the config broker change I've created a weird issue that I could do with some other eyes on please - it seemed easiest to create a cut down reproducer and supply it as a dummy PR.

The code is in examples/10a.odd_error.  As it stand it compiles and runs fine, but if I comment out line 37 in subscriber1.cc and recompile then at run time it generates a tag violation.   The weird bit (to me at least) is that line is in a function that I'm not using anymore - it's a hangover from the previous callback based approach.   However I've clearly created done something to I guess upset the linker ?? 

If I also comment out line 55 (which is the other call to print_config()   ) then that also seems to keep things happy, so I guess its something to do with the global defined in line 25  - but the tag violation is caught in the config_broker compartment, and this value is only even used in those two local calls ?