### PR TITLE
Fix #274 (Bug in Sonata I2C header).

### DIFF
--- a/sdk/include/platform/sunburst/platform-i2c.hh
+++ b/sdk/include/platform/sunburst/platform-i2c.hh
@@ -394,7 +394,7 @@ struct OpenTitanI2c
 	/// Clears the given interrupt.
 	void interrupt_clear(OpenTitanI2cInterrupt interrupt) volatile
 	{
-		interruptState = interruptState & ~interrupt_bit(interrupt);
+		interruptState = interrupt_bit(interrupt);
 	}
 
 	/// Enables the given interrupt.


### PR DESCRIPTION
I2C interrupts now properly cleared by `interrupt_clear()`.